### PR TITLE
UNG-2189 SKID

### DIFF
--- a/main/config.go
+++ b/main/config.go
@@ -35,6 +35,7 @@ const (
 
 	defaultKeyURL      = "https://identity.%s.ubirch.com/api/keyService/v1/pubkey"
 	defaultIdentityURL = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
+	defaultCertificateURL = "https://TODO"
 	//defaultSigningServiceURL = "http://localhost:8080"
 
 	identitiesFileName = "identities.json"
@@ -68,10 +69,11 @@ type Config struct {
 	LogTextFormat    bool                 `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
 	KeyService       string               // key service URL
 	IdentityService  string               // identity service URL
+	CertificateService string               // certificate service URL
 	//SigningService   string               // signing service URL
 	configDir   string // directory where config and protocol ctx are stored
 	secretBytes []byte // the decoded key store secret
-	identities  []*Identity
+	identities  []Identity
 }
 
 func (c *Config) Load(configDir string, filename string) error {

--- a/main/config.go
+++ b/main/config.go
@@ -33,8 +33,8 @@ const (
 
 	PROD_STAGE = "prod"
 
-	defaultKeyURL      = "https://identity.%s.ubirch.com/api/keyService/v1/pubkey"
-	defaultIdentityURL = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
+	defaultKeyURL         = "https://identity.%s.ubirch.com/api/keyService/v1/pubkey"
+	defaultIdentityURL    = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
 	defaultCertificateURL = "https://TODO"
 	//defaultSigningServiceURL = "http://localhost:8080"
 
@@ -50,30 +50,30 @@ const (
 )
 
 type Config struct {
-	Tokens           map[uuid.UUID]string `json:"tokens"`
-	SecretBase64     string               `json:"secret32" envconfig:"secret32"`         // 32 byte secret used to encrypt the key store (mandatory)
-	RegisterAuth     string               `json:"registerAuth"`                          // auth token needed for new identity registration
-	Env              string               `json:"env"`                                   // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
-	DsnInitContainer bool                 `json:"DSN_InitDb" envconfig:"DSN_InitDb"`     // flag to determine if a database should be used for context management
-	DsnHost          string               `json:"DSN_Host" envconfig:"DSN_Host"`         // database host name
-	DsnUser          string               `json:"DSN_User" envconfig:"DSN_User"`         // database user name
-	DsnPassword      string               `json:"DSN_Password" envconfig:"DSN_Password"` // database password
-	DsnDb            string               `json:"DSN_Database" envconfig:"DSN_Database"` // database name
-	TCP_addr         string               `json:"TCP_addr"`                              // the TCP address for the server to listen on, in the form "host:port"
-	TLS              bool                 `json:"TLS"`                                   // enable serving HTTPS endpoints, defaults to 'false'
-	TLS_CertFile     string               `json:"TLSCertFile"`                           // filename of TLS certificate file name, defaults to "cert.pem"
-	TLS_KeyFile      string               `json:"TLSKeyFile"`                            // filename of TLS key file name, defaults to "key.pem"
-	CSR_Country      string               `json:"CSR_country"`                           // subject country for public key Certificate Signing Requests
-	CSR_Organization string               `json:"CSR_organization"`                      // subject organization for public key Certificate Signing Requests
-	Debug            bool                 `json:"debug"`                                 // enable extended debug output, defaults to 'false'
-	LogTextFormat    bool                 `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
-	KeyService       string               // key service URL
-	IdentityService  string               // identity service URL
+	Tokens             map[uuid.UUID]string `json:"tokens"`
+	SecretBase64       string               `json:"secret32" envconfig:"secret32"`         // 32 byte secret used to encrypt the key store (mandatory)
+	RegisterAuth       string               `json:"registerAuth"`                          // auth token needed for new identity registration
+	Env                string               `json:"env"`                                   // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
+	DsnInitContainer   bool                 `json:"DSN_InitDb" envconfig:"DSN_InitDb"`     // flag to determine if a database should be used for context management
+	DsnHost            string               `json:"DSN_Host" envconfig:"DSN_Host"`         // database host name
+	DsnUser            string               `json:"DSN_User" envconfig:"DSN_User"`         // database user name
+	DsnPassword        string               `json:"DSN_Password" envconfig:"DSN_Password"` // database password
+	DsnDb              string               `json:"DSN_Database" envconfig:"DSN_Database"` // database name
+	TCP_addr           string               `json:"TCP_addr"`                              // the TCP address for the server to listen on, in the form "host:port"
+	TLS                bool                 `json:"TLS"`                                   // enable serving HTTPS endpoints, defaults to 'false'
+	TLS_CertFile       string               `json:"TLSCertFile"`                           // filename of TLS certificate file name, defaults to "cert.pem"
+	TLS_KeyFile        string               `json:"TLSKeyFile"`                            // filename of TLS key file name, defaults to "key.pem"
+	CSR_Country        string               `json:"CSR_country"`                           // subject country for public key Certificate Signing Requests
+	CSR_Organization   string               `json:"CSR_organization"`                      // subject organization for public key Certificate Signing Requests
+	Debug              bool                 `json:"debug"`                                 // enable extended debug output, defaults to 'false'
+	LogTextFormat      bool                 `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
+	KeyService         string               // key service URL
+	IdentityService    string               // identity service URL
 	CertificateService string               // certificate service URL
 	//SigningService   string               // signing service URL
 	configDir   string // directory where config and protocol ctx are stored
 	secretBytes []byte // the decoded key store secret
-	identities  []Identity
+	identities  []*Identity
 }
 
 func (c *Config) Load(configDir string, filename string) error {
@@ -196,6 +196,10 @@ func (c *Config) setDefaultURLs() error {
 		c.IdentityService = fmt.Sprintf(defaultIdentityURL, c.Env)
 	}
 
+	if c.CertificateService == "" {
+		c.CertificateService = defaultCertificateURL
+	}
+
 	//if c.SigningService == "" {
 	//	c.SigningService = defaultSigningServiceURL
 	//}
@@ -203,6 +207,7 @@ func (c *Config) setDefaultURLs() error {
 	log.Infof("UBIRCH backend environment: %s", c.Env)
 	log.Debugf(" - Key Service:      %s", c.KeyService)
 	log.Debugf(" - Identity Service: %s", c.IdentityService)
+	log.Debugf(" - Certificates:      %s", c.CertificateService)
 	//log.Debugf(" - Signing Service:  %s", c.SigningService)
 
 	return nil

--- a/main/config.go
+++ b/main/config.go
@@ -33,9 +33,8 @@ const (
 
 	PROD_STAGE = "prod"
 
-	defaultKeyURL         = "https://identity.%s.ubirch.com/api/keyService/v1/pubkey"
-	defaultIdentityURL    = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
-	defaultCertificateURL = "https://TODO"
+	defaultKeyURL      = "https://identity.%s.ubirch.com/api/keyService/v1/pubkey"
+	defaultIdentityURL = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
 	//defaultSigningServiceURL = "http://localhost:8080"
 
 	identitiesFileName = "identities.json"
@@ -50,26 +49,26 @@ const (
 )
 
 type Config struct {
-	Tokens             map[uuid.UUID]string `json:"tokens"`
-	SecretBase64       string               `json:"secret32" envconfig:"secret32"`         // 32 byte secret used to encrypt the key store (mandatory)
-	RegisterAuth       string               `json:"registerAuth"`                          // auth token needed for new identity registration
-	Env                string               `json:"env"`                                   // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
-	DsnInitContainer   bool                 `json:"DSN_InitDb" envconfig:"DSN_InitDb"`     // flag to determine if a database should be used for context management
-	DsnHost            string               `json:"DSN_Host" envconfig:"DSN_Host"`         // database host name
-	DsnUser            string               `json:"DSN_User" envconfig:"DSN_User"`         // database user name
-	DsnPassword        string               `json:"DSN_Password" envconfig:"DSN_Password"` // database password
-	DsnDb              string               `json:"DSN_Database" envconfig:"DSN_Database"` // database name
-	TCP_addr           string               `json:"TCP_addr"`                              // the TCP address for the server to listen on, in the form "host:port"
-	TLS                bool                 `json:"TLS"`                                   // enable serving HTTPS endpoints, defaults to 'false'
-	TLS_CertFile       string               `json:"TLSCertFile"`                           // filename of TLS certificate file name, defaults to "cert.pem"
-	TLS_KeyFile        string               `json:"TLSKeyFile"`                            // filename of TLS key file name, defaults to "key.pem"
-	CSR_Country        string               `json:"CSR_country"`                           // subject country for public key Certificate Signing Requests
-	CSR_Organization   string               `json:"CSR_organization"`                      // subject organization for public key Certificate Signing Requests
-	Debug              bool                 `json:"debug"`                                 // enable extended debug output, defaults to 'false'
-	LogTextFormat      bool                 `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
-	KeyService         string               // key service URL
-	IdentityService    string               // identity service URL
-	CertificateService string               // certificate service URL
+	Tokens            map[uuid.UUID]string `json:"tokens"`
+	SecretBase64      string               `json:"secret32" envconfig:"secret32"`         // 32 byte secret used to encrypt the key store (mandatory)
+	RegisterAuth      string               `json:"registerAuth"`                          // auth token needed for new identity registration
+	Env               string               `json:"env"`                                   // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
+	DsnInitContainer  bool                 `json:"DSN_InitDb" envconfig:"DSN_InitDb"`     // flag to determine if a database should be used for context management
+	DsnHost           string               `json:"DSN_Host" envconfig:"DSN_Host"`         // database host name
+	DsnUser           string               `json:"DSN_User" envconfig:"DSN_User"`         // database user name
+	DsnPassword       string               `json:"DSN_Password" envconfig:"DSN_Password"` // database password
+	DsnDb             string               `json:"DSN_Database" envconfig:"DSN_Database"` // database name
+	TCP_addr          string               `json:"TCP_addr"`                              // the TCP address for the server to listen on, in the form "host:port"
+	TLS               bool                 `json:"TLS"`                                   // enable serving HTTPS endpoints, defaults to 'false'
+	TLS_CertFile      string               `json:"TLSCertFile"`                           // filename of TLS certificate file name, defaults to "cert.pem"
+	TLS_KeyFile       string               `json:"TLSKeyFile"`                            // filename of TLS key file name, defaults to "key.pem"
+	CSR_Country       string               `json:"CSR_country"`                           // subject country for public key Certificate Signing Requests
+	CSR_Organization  string               `json:"CSR_organization"`                      // subject organization for public key Certificate Signing Requests
+	Debug             bool                 `json:"debug"`                                 // enable extended debug output, defaults to 'false'
+	LogTextFormat     bool                 `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
+	CertificateServer string               `json:"certificateServer"`                     // certificate server URL
+	KeyService        string               // key service URL
+	IdentityService   string               // identity service URL
 	//SigningService   string               // signing service URL
 	configDir   string // directory where config and protocol ctx are stored
 	secretBytes []byte // the decoded key store secret
@@ -143,6 +142,10 @@ func (c *Config) checkMandatory() error {
 		return fmt.Errorf("auth token for identity registration ('registerAuth') wasn't set")
 	}
 
+	if c.CertificateServer == "" {
+		return fmt.Errorf("missing 'certificateServer' in configuration")
+	}
+
 	return nil
 }
 
@@ -196,10 +199,6 @@ func (c *Config) setDefaultURLs() error {
 		c.IdentityService = fmt.Sprintf(defaultIdentityURL, c.Env)
 	}
 
-	if c.CertificateService == "" {
-		c.CertificateService = defaultCertificateURL
-	}
-
 	//if c.SigningService == "" {
 	//	c.SigningService = defaultSigningServiceURL
 	//}
@@ -207,7 +206,7 @@ func (c *Config) setDefaultURLs() error {
 	log.Infof("UBIRCH backend environment: %s", c.Env)
 	log.Debugf(" - Key Service:      %s", c.KeyService)
 	log.Debugf(" - Identity Service: %s", c.IdentityService)
-	log.Debugf(" - Certificates:      %s", c.CertificateService)
+	log.Debugf(" - Certificates:     %s", c.CertificateServer)
 	//log.Debugf(" - Signing Service:  %s", c.SigningService)
 
 	return nil

--- a/main/context_manager.go
+++ b/main/context_manager.go
@@ -35,9 +35,8 @@ type ContextManager interface {
 
 	GetAuthToken(uid uuid.UUID) (string, error)
 
-	//ExistsSKID(uid uuid.UUID) bool
-	//GetSKID(uid uuid.UUID) (skid []byte, err error)
-	//SetSKID(uid uuid.UUID, skid []byte) error
+	ExistsUuidForPublicKey(pubKey []byte) (bool, error)
+	GetUuidForPublicKey(pubKey []byte) (uuid.UUID, error)
 }
 
 func GetCtxManager(c *Config) (ContextManager, error) {

--- a/main/extended_client.go
+++ b/main/extended_client.go
@@ -32,8 +32,8 @@ import (
 
 type ExtendedClient struct {
 	clients.Client
-	CertificateServiceURL string
-	SigningServiceURL     string
+	SigningServiceURL    string
+	CertificateServerURL string
 }
 
 func (c *ExtendedClient) SendToUbirchSigningService(uid uuid.UUID, auth string, upp []byte) (h.HTTPResponse, error) {
@@ -64,9 +64,9 @@ type certificates struct {
 }
 
 func (c *ExtendedClient) RequestCertificates() ([]certificates, error) {
-	log.Debugf("requesting certificates from %s", c.CertificateServiceURL)
+	log.Debugf("requesting certificates from %s", c.CertificateServerURL)
 
-	resp, err := http.Get(c.CertificateServiceURL)
+	resp, err := http.Get(c.CertificateServerURL)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func (c *ExtendedClient) RequestCertificates() ([]certificates, error) {
 
 	if h.HttpFailed(resp.StatusCode) {
 		respBodyBytes, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf("retrieving certificates from %s failed: (%s) %s", c.CertificateServiceURL, resp.Status, string(respBodyBytes))
+		return nil, fmt.Errorf("retrieving certificates from %s failed: (%s) %s", c.CertificateServerURL, resp.Status, string(respBodyBytes))
 	}
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/main/main.go
+++ b/main/main.go
@@ -138,8 +138,8 @@ func main() {
 	client := &ExtendedClient{}
 	client.KeyServiceURL = conf.KeyService
 	client.IdentityServiceURL = conf.IdentityService
-	client.CertificateServiceURL = conf.CertificateService
 	//todo client.SigningServiceURL = conf.SigningService
+	client.CertificateServerURL = conf.CertificateServer
 
 	protocol, err := NewProtocol(ctxManager, conf.secretBytes, client)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -138,7 +138,8 @@ func main() {
 	client := &ExtendedClient{}
 	client.KeyServiceURL = conf.KeyService
 	client.IdentityServiceURL = conf.IdentityService
-	//todo client.signingServiceURL = conf.SigningService
+	client.CertificateServiceURL = conf.CertificateService
+	//todo client.SigningServiceURL = conf.SigningService
 
 	protocol, err := NewProtocol(ctxManager, conf.secretBytes, client)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -171,6 +171,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	protocol.loadSKIDs() // todo scheduler
+
 	coseSigner, err := NewCoseSigner(protocol)
 	if err != nil {
 		log.Fatal(err)

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -220,11 +220,6 @@ func (p *Protocol) GetSKID(uid uuid.UUID) ([]byte, error) {
 	return skid, nil
 }
 
-/*
-type Certificate
-    func ParseCertificate(asn1Data []byte) (*Certificate, error)
-    func (c *Certificate) CheckSignature(algo SignatureAlgorithm, signed, signature []byte) error
-*/
 func (p *Protocol) loadSKIDs() {
 	certs, err := p.RequestCertificates()
 	if err != nil {

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -233,7 +233,7 @@ func (p *Protocol) loadSKIDs() {
 
 	for _, cert := range certs {
 		block, _ := pem.Decode(cert.RawData)
-		if block == nil {
+		if block == nil || block.Bytes == nil {
 			log.Fatal(fmt.Errorf("unable to parse PEM block"))
 		}
 		certificate, err := x509.ParseCertificate(block.Bytes)

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/pem"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-client-go/main/adapters/encrypters"
@@ -177,8 +179,14 @@ func (p *Protocol) GetSKID(uid uuid.UUID) ([]byte, error) {
 		}
 
 		// generate SKID from certificate => the first 8 bytes of the sha256 hash of the DER-encoded X.509 certificate
-		// todo convert to DER?
-		hash := sha256.Sum256(cert)
+		// todo ? convert to DER
+		block, _ := pem.Decode(cert)
+		if block == nil {
+			return nil, fmt.Errorf("unable to parse PEM block")
+		}
+		certDER := block.Bytes
+
+		hash := sha256.Sum256(certDER)
 		skid := hash[:SkidLen]
 
 		err = p.SetSKID(uid, skid)

--- a/main/services.go
+++ b/main/services.go
@@ -82,7 +82,7 @@ func (s *COSEService) directUUID() http.HandlerFunc {
 }
 
 func (s *COSEService) handleRequest(w http.ResponseWriter, r *http.Request, uid uuid.UUID) {
-	exists, err := s.protocol.ExistsPrivateKey(uid)
+	exists, err := s.Protocol.ExistsPrivateKey(uid)
 	if err != nil {
 		log.Errorf("%s: %v", uid, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -92,7 +92,7 @@ func (s *COSEService) handleRequest(w http.ResponseWriter, r *http.Request, uid 
 		h.Error(uid, w, fmt.Errorf("unknown UUID"), http.StatusNotFound)
 		return
 	}
-	authToken, err := s.protocol.GetAuthToken(uid)
+	authToken, err := s.Protocol.GetAuthToken(uid)
 	if err != nil {
 		log.Errorf("%s: %v", uid, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/main/services.go
+++ b/main/services.go
@@ -82,7 +82,7 @@ func (s *COSEService) directUUID() http.HandlerFunc {
 }
 
 func (s *COSEService) handleRequest(w http.ResponseWriter, r *http.Request, uid uuid.UUID) {
-	exists, err := s.Protocol.ExistsPrivateKey(uid)
+	exists, err := s.ExistsPrivateKey(uid)
 	if err != nil {
 		log.Errorf("%s: %v", uid, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -92,7 +92,7 @@ func (s *COSEService) handleRequest(w http.ResponseWriter, r *http.Request, uid 
 		h.Error(uid, w, fmt.Errorf("unknown UUID"), http.StatusNotFound)
 		return
 	}
-	authToken, err := s.Protocol.GetAuthToken(uid)
+	authToken, err := s.GetAuthToken(uid)
 	if err != nil {
 		log.Errorf("%s: %v", uid, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)


### PR DESCRIPTION
**Changed:**

- using the "short KID" (SKID) as KID value in the unprotected header of the COSE object, which is the first 8 bytes of the sha256 hash of the DER-encoded X.509 certificate of the public key, according to the hcert specification

- **BREAKING CHANGE**: an endpoint for retrieving a list of certificates which match known public keys must be set via config

**ToDo:**

- verify signature of certificate list

