### PR TITLE
UNG-2440 enable TLS DB connections

### DIFF
--- a/main/config.go
+++ b/main/config.go
@@ -56,11 +56,7 @@ type Config struct {
 	SecretBase64            string               `json:"secret32" envconfig:"SECRET32"`                                 // 32 byte secret used to encrypt the key store (mandatory)
 	RegisterAuth            string               `json:"registerAuth" envconfig:"REGISTERAUTH"`                         // auth token needed for new identity registration
 	Env                     string               `json:"env"`                                                           // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
-	DsnInitContainer        bool                 `json:"DSN_InitDb" envconfig:"DSN_INITDB"`                             // flag to determine if a database should be used for context management
-	DsnHost                 string               `json:"DSN_Host" envconfig:"DSN_HOST"`                                 // database host name
-	DsnUser                 string               `json:"DSN_User" envconfig:"DSN_USER"`                                 // database user name
-	DsnPassword             string               `json:"DSN_Password" envconfig:"DSN_PASSWORD"`                         // database password
-	DsnDb                   string               `json:"DSN_Database" envconfig:"DSN_DATABASE"`                         // database name
+	PostgresDSN             string               `json:"postgresDSN" envconfig:"POSTGRES_DSN"`                          // data source name for postgres database
 	TCP_addr                string               `json:"TCP_addr"`                                                      // the TCP address for the server to listen on, in the form "host:port"
 	TLS                     bool                 `json:"TLS"`                                                           // enable serving HTTPS endpoints, defaults to 'false'
 	TLS_CertFile            string               `json:"TLSCertFile"`                                                   // filename of TLS certificate file name, defaults to "cert.pem"

--- a/main/context_manager.go
+++ b/main/context_manager.go
@@ -20,7 +20,6 @@ var (
 
 type ContextManager interface {
 	StartTransaction(ctx context.Context) (transactionCtx interface{}, err error)
-	StartTransactionWithLock(ctx context.Context, uid uuid.UUID) (transactionCtx interface{}, err error)
 	CloseTransaction(transactionCtx interface{}, commit bool) error
 
 	StoreNewIdentity(tx interface{}, id Identity) error
@@ -40,8 +39,8 @@ type ContextManager interface {
 }
 
 func GetCtxManager(c *Config) (ContextManager, error) {
-	if c.DsnInitContainer {
-		return NewSqlDatabaseInfo(c)
+	if c.PostgresDSN != "" {
+		return NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName)
 	} else {
 		return nil, fmt.Errorf("file-based context management is not supported in the current version")
 	}

--- a/main/database_test.go
+++ b/main/database_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const (
+	TestTableName = "test_cose_identity"
+	TestUUID      = "2336c75d-a14a-47dd-80d9-3cbe9d560433"
+	TestAuthToken = "TEST_auth"
+	TestPrivKey   = "Qkp+ZVAlEKCQNvI+OCbY7LKcQVW5iKfFMfzedTI3uG0="
+	TestPubKey    = "bvXP3mQ42hXpcqo0ms7Lr1n6Q4L5CsS8HXk0mdXlsXLwYjd35jLlX3iHrXMgUH92N8ujbZ3h3TnLk8a0GikUbg=="
+)
+
+var (
+	testIdentity = initTestIdentity()
+)
+
+func TestDatabaseManager(t *testing.T) {
+	dbManager, err := initDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanUp(t, dbManager)
+
+	// check not exists
+	exists, err := dbManager.ExistsPublicKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Errorf("dbManager.ExistsPublicKey returned TRUE")
+	}
+
+	exists, err = dbManager.ExistsPrivateKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Errorf("dbManager.ExistsPrivateKey returned TRUE")
+	}
+
+	// store identity
+	tx, err := dbManager.StartTransaction(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dbManager.StoreNewIdentity(tx, *testIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dbManager.CloseTransaction(tx, Commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check exists
+	exists, err = dbManager.ExistsPublicKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Errorf("dbManager.ExistsPublicKey returned FALSE")
+	}
+	exists, err = dbManager.ExistsPrivateKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Errorf("dbManager.ExistsPrivateKey returned FALSE")
+	}
+
+	// get attributes
+	auth, err := dbManager.GetAuthToken(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth != testIdentity.AuthToken {
+		t.Error("GetAuthToken returned unexpected value")
+	}
+
+	priv, err := dbManager.GetPrivateKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(priv, testIdentity.PrivateKey) {
+		t.Error("GetPrivateKey returned unexpected value")
+	}
+
+	pub, err := dbManager.GetPublicKey(testIdentity.Uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pub, testIdentity.PublicKey) {
+		t.Error("GetPublicKey returned unexpected value")
+	}
+}
+
+func initDB() (*DatabaseManager, error) {
+	conf := &Config{}
+	err := conf.Load("", "config.json")
+	if err != nil {
+		return nil, fmt.Errorf("ERROR: unable to load configuration: %s", err)
+	}
+
+	return NewSqlDatabaseInfo(conf.PostgresDSN, TestTableName)
+}
+
+func initTestIdentity() *Identity {
+	priv, _ := base64.StdEncoding.DecodeString(TestPrivKey)
+	pub, _ := base64.StdEncoding.DecodeString(TestPubKey)
+
+	return &Identity{
+		Uid:        uuid.MustParse(TestUUID),
+		PrivateKey: priv,
+		PublicKey:  pub,
+		AuthToken:  TestAuthToken,
+	}
+}
+
+func cleanUp(t *testing.T, dbManager *DatabaseManager) {
+	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE uid = $1;", TestTableName)
+	_, err := dbManager.db.Exec(deleteQuery, TestUUID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	dropTableQuery := fmt.Sprintf("DROP TABLE %s;", TestTableName)
+	_, err = dbManager.db.Exec(dropTableQuery)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/main/database_test.go
+++ b/main/database_test.go
@@ -46,6 +46,14 @@ func TestDatabaseManager(t *testing.T) {
 		t.Errorf("dbManager.ExistsPrivateKey returned TRUE")
 	}
 
+	exists, err = dbManager.ExistsUuidForPublicKey(testIdentity.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("dbManager.ExistsUuidForPublicKey returned TRUE")
+	}
+
 	// store identity
 	tx, err := dbManager.StartTransaction(context.Background())
 	if err != nil {
@@ -70,12 +78,21 @@ func TestDatabaseManager(t *testing.T) {
 	if !exists {
 		t.Errorf("dbManager.ExistsPublicKey returned FALSE")
 	}
+
 	exists, err = dbManager.ExistsPrivateKey(testIdentity.Uid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !exists {
 		t.Errorf("dbManager.ExistsPrivateKey returned FALSE")
+	}
+
+	exists, err = dbManager.ExistsUuidForPublicKey(testIdentity.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("public key not found")
 	}
 
 	// get attributes
@@ -101,6 +118,14 @@ func TestDatabaseManager(t *testing.T) {
 	}
 	if !bytes.Equal(pub, testIdentity.PublicKey) {
 		t.Error("GetPublicKey returned unexpected value")
+	}
+
+	uid, err := dbManager.GetUuidForPublicKey(testIdentity.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(uid[:], testIdentity.Uid[:]) {
+		t.Error("GetUuidForPublicKey returned unexpected value")
 	}
 }
 

--- a/main/migrator.go
+++ b/main/migrator.go
@@ -24,7 +24,7 @@ func MigrateFileToDB(c *Config) error {
 		return err
 	}
 
-	dbManager, err := NewSqlDatabaseInfo(c)
+	dbManager, err := NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName)
 	if err != nil {
 		return err
 	}

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -113,10 +113,6 @@ func (p *Protocol) StartTransaction(ctx context.Context) (transactionCtx interfa
 	return p.ctxManager.StartTransaction(ctx)
 }
 
-func (p *Protocol) StartTransactionWithLock(ctx context.Context, uid uuid.UUID) (transactionCtx interface{}, err error) {
-	return p.ctxManager.StartTransactionWithLock(ctx, uid)
-}
-
 func (p *Protocol) CloseTransaction(tx interface{}, commit bool) error {
 	return p.ctxManager.CloseTransaction(tx, commit)
 }


### PR DESCRIPTION
**Changed:**

- configuration for postgres database consists of only the DSN: `PostgresDSN`
  - deprecated `DSN_InitDb`, client will connect to DB if `PostgresDSN` is set
  - deprecated `DSN_Host`, `DSN_User`, `DSN_Password`, `DSN_Database`, replaced by `PostgresDSN`

**Added:**
- tests for database