### PR TITLE
UNG-2591 DB parameters

### DIFF
--- a/main/context_manager.go
+++ b/main/context_manager.go
@@ -34,7 +34,7 @@ type ContextManager interface {
 
 func GetCtxManager(c *Config) (ContextManager, error) {
 	if c.PostgresDSN != "" {
-		return NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName)
+		return NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName, &c.dbParams)
 	} else {
 		return nil, fmt.Errorf("file-based context management is not supported in the current version")
 	}

--- a/main/context_manager.go
+++ b/main/context_manager.go
@@ -25,16 +25,10 @@ type ContextManager interface {
 	StoreNewIdentity(tx interface{}, id Identity) error
 
 	ExistsPrivateKey(uid uuid.UUID) (bool, error)
+
 	GetPrivateKey(uid uuid.UUID) (privKey []byte, err error)
-	//SetPrivateKey(tx interface{}, uid uuid.UUID, privKey []byte) error
-
-	ExistsPublicKey(uid uuid.UUID) (bool, error)
 	GetPublicKey(uid uuid.UUID) (pubKey []byte, err error)
-	//SetPublicKey(tx interface{}, uid uuid.UUID, pubKey []byte) error
-
 	GetAuthToken(uid uuid.UUID) (string, error)
-
-	ExistsUuidForPublicKey(pubKey []byte) (bool, error)
 	GetUuidForPublicKey(pubKey []byte) (uuid.UUID, error)
 }
 

--- a/main/database.go
+++ b/main/database.go
@@ -103,9 +103,9 @@ func NewSqlDatabaseInfo(dataSourceName, tableName string) (*DatabaseManager, err
 	if err != nil {
 		return nil, err
 	}
-	pg.SetMaxOpenConns(100)
-	pg.SetMaxIdleConns(70)
-	pg.SetConnMaxLifetime(10 * time.Minute)
+	pg.SetMaxOpenConns(50)
+	pg.SetMaxIdleConns(25)
+	pg.SetConnMaxLifetime(2 * time.Minute)
 	if err = pg.Ping(); err != nil {
 		return nil, err
 	}

--- a/main/database.go
+++ b/main/database.go
@@ -67,9 +67,9 @@ func NewSqlDatabaseInfo(dataSourceName, tableName string) (*DatabaseManager, err
 	if err != nil {
 		return nil, err
 	}
-	pg.SetMaxOpenConns(50)
-	pg.SetMaxIdleConns(25)
-	pg.SetConnMaxLifetime(2 * time.Minute)
+	pg.SetMaxOpenConns(10)
+	pg.SetMaxIdleConns(10)
+	pg.SetConnMaxLifetime(time.Minute)
 	if err = pg.Ping(); err != nil {
 		return nil, err
 	}

--- a/main/database.go
+++ b/main/database.go
@@ -114,7 +114,7 @@ func NewSqlDatabaseInfo(dataSourceName, tableName string) (*DatabaseManager, err
 
 	dbManager := &DatabaseManager{
 		options: &sql.TxOptions{
-			Isolation: sql.LevelReadCommitted,
+			Isolation: sql.LevelSerializable,
 			ReadOnly:  false,
 		},
 		db:        pg,

--- a/main/database.go
+++ b/main/database.go
@@ -239,28 +239,6 @@ func (dm *DatabaseManager) StoreNewIdentity(transactionCtx interface{}, identity
 		return fmt.Errorf("transactionCtx for database manager is not of expected type *sql.Tx")
 	}
 
-	// make sure identity does not exist yet
-	var uid string
-
-	query := fmt.Sprintf("SELECT uid FROM %s WHERE uid = $1 FOR UPDATE", dm.tableName)
-
-	err := tx.QueryRow(query, identity.Uid.String()).Scan(&uid)
-	if err != nil {
-		if dm.isConnectionAvailable(err) {
-			return dm.StoreNewIdentity(tx, identity)
-		}
-		if err == sql.ErrNoRows {
-			// there were no rows, but otherwise no error occurred
-			return dm.storeIdentity(tx, identity)
-		} else {
-			return err
-		}
-	} else {
-		return ErrExists
-	}
-}
-
-func (dm *DatabaseManager) storeIdentity(tx *sql.Tx, identity Identity) error {
 	query := fmt.Sprintf(
 		"INSERT INTO %s (uid, private_key, public_key, auth_token) VALUES ($1, $2, $3, $4);",
 		dm.tableName)
@@ -268,7 +246,7 @@ func (dm *DatabaseManager) storeIdentity(tx *sql.Tx, identity Identity) error {
 	_, err := tx.Exec(query, &identity.Uid, &identity.PrivateKey, &identity.PublicKey, &identity.AuthToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
-			return dm.storeIdentity(tx, identity)
+			return dm.StoreNewIdentity(tx, identity)
 		}
 		return err
 	}

--- a/main/database_test.go
+++ b/main/database_test.go
@@ -207,6 +207,13 @@ type dbConfig struct {
 }
 
 func initDB() (*DatabaseManager, error) {
+	testDbParams := &DatabaseParams{
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 2,
+		ConnMaxIdleTime: 1,
+	}
+
 	fileHandle, err := os.Open("config.json")
 	if err != nil {
 		return nil, err
@@ -219,7 +226,7 @@ func initDB() (*DatabaseManager, error) {
 		return nil, err
 	}
 
-	return NewSqlDatabaseInfo(c.PostgresDSN, testTableName)
+	return NewSqlDatabaseInfo(c.PostgresDSN, testTableName, testDbParams)
 }
 
 func cleanUp(t *testing.T, dm *DatabaseManager) {

--- a/main/database_test.go
+++ b/main/database_test.go
@@ -4,163 +4,311 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"testing"
-
 	"github.com/google/uuid"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
 )
 
 const (
-	TestTableName = "test_cose_identity"
-	TestUUID      = "2336c75d-a14a-47dd-80d9-3cbe9d560433"
-	TestAuthToken = "TEST_auth"
-	TestPrivKey   = "Qkp+ZVAlEKCQNvI+OCbY7LKcQVW5iKfFMfzedTI3uG0="
-	TestPubKey    = "bvXP3mQ42hXpcqo0ms7Lr1n6Q4L5CsS8HXk0mdXlsXLwYjd35jLlX3iHrXMgUH92N8ujbZ3h3TnLk8a0GikUbg=="
-)
-
-var (
-	testIdentity = initTestIdentity()
+	testTableName = "test_cose_identity"
+	testLoad      = 10000
 )
 
 func TestDatabaseManager(t *testing.T) {
-	dbManager, err := initDB()
+	dm, err := initDB()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanUp(t, dbManager)
+	defer cleanUp(t, dm)
+
+	testIdentity := generateRandomIdentity()
 
 	// check not exists
-	exists, err := dbManager.ExistsPublicKey(testIdentity.Uid)
+	exists, err := dm.ExistsPrivateKey(testIdentity.Uid)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if exists {
-		t.Errorf("dbManager.ExistsPublicKey returned TRUE")
+		t.Error("ExistsPrivateKey returned TRUE")
 	}
 
-	exists, err = dbManager.ExistsPrivateKey(testIdentity.Uid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if exists {
-		t.Errorf("dbManager.ExistsPrivateKey returned TRUE")
+	_, err = dm.GetPrivateKey(testIdentity.Uid)
+	if err != ErrNotExist {
+		t.Error("GetPrivateKey did not return ErrNotExist")
 	}
 
-	exists, err = dbManager.ExistsUuidForPublicKey(testIdentity.PublicKey)
-	if err != nil {
-		t.Fatal(err)
+	_, err = dm.GetPublicKey(testIdentity.Uid)
+	if err != ErrNotExist {
+		t.Error("GetPublicKey did not return ErrNotExist")
 	}
-	if exists {
-		t.Error("dbManager.ExistsUuidForPublicKey returned TRUE")
+
+	_, err = dm.GetAuthToken(testIdentity.Uid)
+	if err != ErrNotExist {
+		t.Error("GetAuthToken did not return ErrNotExist")
+	}
+
+	_, err = dm.GetUuidForPublicKey(testIdentity.PublicKey)
+	if err != ErrNotExist {
+		t.Error("GetUuidForPublicKey did not return ErrNotExist")
 	}
 
 	// store identity
-	tx, err := dbManager.StartTransaction(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tx, err := dm.StartTransaction(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = dbManager.StoreNewIdentity(tx, *testIdentity)
+	err = dm.StoreNewIdentity(tx, *testIdentity)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = dbManager.CloseTransaction(tx, Commit)
+	err = dm.CloseTransaction(tx, Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check exists
-	exists, err = dbManager.ExistsPublicKey(testIdentity.Uid)
+	exists, err = dm.ExistsPrivateKey(testIdentity.Uid)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !exists {
-		t.Errorf("dbManager.ExistsPublicKey returned FALSE")
-	}
-
-	exists, err = dbManager.ExistsPrivateKey(testIdentity.Uid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !exists {
-		t.Errorf("dbManager.ExistsPrivateKey returned FALSE")
-	}
-
-	exists, err = dbManager.ExistsUuidForPublicKey(testIdentity.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !exists {
-		t.Error("public key not found")
+		t.Error("ExistsPrivateKey returned FALSE")
 	}
 
 	// get attributes
-	auth, err := dbManager.GetAuthToken(testIdentity.Uid)
+	priv, err := dm.GetPrivateKey(testIdentity.Uid)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if auth != testIdentity.AuthToken {
-		t.Error("GetAuthToken returned unexpected value")
-	}
-
-	priv, err := dbManager.GetPrivateKey(testIdentity.Uid)
-	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !bytes.Equal(priv, testIdentity.PrivateKey) {
 		t.Error("GetPrivateKey returned unexpected value")
 	}
 
-	pub, err := dbManager.GetPublicKey(testIdentity.Uid)
+	pub, err := dm.GetPublicKey(testIdentity.Uid)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !bytes.Equal(pub, testIdentity.PublicKey) {
 		t.Error("GetPublicKey returned unexpected value")
 	}
 
-	uid, err := dbManager.GetUuidForPublicKey(testIdentity.PublicKey)
+	auth, err := dm.GetAuthToken(testIdentity.Uid)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+	}
+	if auth != testIdentity.AuthToken {
+		t.Error("GetAuthToken returned unexpected value")
+	}
+
+	uid, err := dm.GetUuidForPublicKey(testIdentity.PublicKey)
+	if err != nil {
+		t.Error(err)
 	}
 	if !bytes.Equal(uid[:], testIdentity.Uid[:]) {
 		t.Error("GetUuidForPublicKey returned unexpected value")
 	}
 }
 
-func initDB() (*DatabaseManager, error) {
-	conf := &Config{}
-	err := conf.Load("", "config.json")
+func TestStoreExisting(t *testing.T) {
+	dm, err := initDB()
 	if err != nil {
-		return nil, fmt.Errorf("ERROR: unable to load configuration: %s", err)
+		t.Fatal(err)
+	}
+	defer cleanUp(t, dm)
+
+	testIdentity := generateRandomIdentity()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// store identity
+	tx, err := dm.StartTransaction(ctx)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	return NewSqlDatabaseInfo(conf.PostgresDSN, TestTableName)
+	err = dm.StoreNewIdentity(tx, *testIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dm.CloseTransaction(tx, Commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// store same identity again
+	tx2, err := dm.StartTransaction(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dm.StoreNewIdentity(tx2, *testIdentity)
+	if err == nil {
+		t.Fatal("existing identity was overwritten")
+	}
 }
 
-func initTestIdentity() *Identity {
-	priv, _ := base64.StdEncoding.DecodeString(TestPrivKey)
-	pub, _ := base64.StdEncoding.DecodeString(TestPubKey)
+func TestDatabaseLoad(t *testing.T) {
+	wg := &sync.WaitGroup{}
+
+	dm, err := initDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanUp(t, dm)
+
+	// generate identities
+	var testIdentities []*Identity
+	for i := 0; i < testLoad; i++ {
+		testIdentities = append(testIdentities, generateRandomIdentity())
+	}
+
+	// store identities
+	for i, testId := range testIdentities {
+		wg.Add(1)
+		go func(idx int, identity *Identity) {
+			err := storeIdentity(dm, identity, wg)
+			if err != nil {
+				t.Errorf("%s: identity could not be stored: %v", identity.Uid, err)
+			}
+		}(i, testId)
+	}
+	wg.Wait()
+
+	// check identities
+	for _, testId := range testIdentities {
+		wg.Add(1)
+		go func(id *Identity) {
+			err := checkIdentity(dm, id, wg)
+			if err != nil {
+				t.Errorf("%s: %v", id.Uid, err)
+			}
+		}(testId)
+	}
+	wg.Wait()
+
+	if dm.db.Stats().OpenConnections > dm.db.Stats().Idle {
+		t.Errorf("%d open connections, %d idle", dm.db.Stats().OpenConnections, dm.db.Stats().Idle)
+	}
+}
+
+type dbConfig struct {
+	PostgresDSN string
+}
+
+func initDB() (*DatabaseManager, error) {
+	fileHandle, err := os.Open("config.json")
+	if err != nil {
+		return nil, err
+	}
+	defer fileHandle.Close()
+
+	c := &dbConfig{}
+	err = json.NewDecoder(fileHandle).Decode(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSqlDatabaseInfo(c.PostgresDSN, testTableName)
+}
+
+func cleanUp(t *testing.T, dm *DatabaseManager) {
+	dropTableQuery := fmt.Sprintf("DROP TABLE %s;", testTableName)
+	_, err := dm.db.Exec(dropTableQuery)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func generateRandomIdentity() *Identity {
+	priv := make([]byte, 32)
+	rand.Read(priv)
+
+	pub := make([]byte, 64)
+	rand.Read(pub)
+
+	auth := make([]byte, 16)
+	rand.Read(auth)
 
 	return &Identity{
-		Uid:        uuid.MustParse(TestUUID),
+		Uid:        uuid.New(),
 		PrivateKey: priv,
 		PublicKey:  pub,
-		AuthToken:  TestAuthToken,
+		AuthToken:  base64.StdEncoding.EncodeToString(auth),
 	}
 }
 
-func cleanUp(t *testing.T, dbManager *DatabaseManager) {
-	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE uid = $1;", TestTableName)
-	_, err := dbManager.db.Exec(deleteQuery, TestUUID)
+func storeIdentity(dm *DatabaseManager, id *Identity, wg *sync.WaitGroup) error {
+	defer wg.Done()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tx, err := dm.StartTransaction(ctx)
 	if err != nil {
-		t.Error(err)
+		return err
 	}
 
-	dropTableQuery := fmt.Sprintf("DROP TABLE %s;", TestTableName)
-	_, err = dbManager.db.Exec(dropTableQuery)
+	err = dm.StoreNewIdentity(tx, *id)
 	if err != nil {
-		t.Error(err)
+		return err
 	}
+
+	return dm.CloseTransaction(tx, Commit)
+}
+
+func checkIdentity(dm *DatabaseManager, id *Identity, wg *sync.WaitGroup) error {
+	defer wg.Done()
+
+	exists, err := dm.ExistsPrivateKey(id.Uid)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("ExistsPrivateKey returned FALSE")
+	}
+
+	auth, err := dm.GetAuthToken(id.Uid)
+	if err != nil {
+		return err
+	}
+	if auth != id.AuthToken {
+		return fmt.Errorf("GetAuthToken returned unexpected value: %s, expected: %s", auth, id.AuthToken)
+	}
+
+	priv, err := dm.GetPrivateKey(id.Uid)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(priv, id.PrivateKey) {
+		return fmt.Errorf("GetPrivateKey returned unexpected value: %s, expected: %s", priv, id.PrivateKey)
+	}
+
+	pub, err := dm.GetPublicKey(id.Uid)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(pub, id.PublicKey) {
+		return fmt.Errorf("GetPublicKey returned unexpected value: %s, expected: %s", pub, id.PublicKey)
+	}
+
+	uid, err := dm.GetUuidForPublicKey(id.PublicKey)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(uid[:], id.Uid[:]) {
+		return fmt.Errorf("GetUuidForPublicKey returned unexpected value: %s, expected: %s", uid, id.Uid)
+	}
+
+	return nil
 }

--- a/main/extended_client.go
+++ b/main/extended_client.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	h "github.com/ubirch/ubirch-client-go/main/adapters/httphelper"
 	urlpkg "net/url"
 )
@@ -72,8 +71,6 @@ type Certificate struct {
 type Verify func(pubKeyPEM []byte, data []byte, signature []byte) (bool, error)
 
 func (c *ExtendedClient) RequestCertificateList(verify Verify) ([]Certificate, error) {
-	log.Debugf("requesting public key certificate list")
-
 	respBodyBytes, err := c.getWithCertPinning(c.CertificateServerURL)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving public key certificate list failed: %v", err)

--- a/main/migrator.go
+++ b/main/migrator.go
@@ -73,6 +73,14 @@ func migrateIdentities(dm *DatabaseManager, identities *[]*Identity) error {
 	for i, id := range *identities {
 		log.Infof("%4d: %s", i+1, id.Uid)
 
+		exists, err := dm.ExistsPrivateKey(id.Uid)
+		if err != nil {
+			return err
+		}
+		if exists {
+			log.Warnf("%s: identity already exists in database", id.Uid)
+		}
+
 		if len(id.PrivateKey) == 0 {
 			return fmt.Errorf("%s: empty private key", id.Uid)
 		}
@@ -87,11 +95,7 @@ func migrateIdentities(dm *DatabaseManager, identities *[]*Identity) error {
 
 		err = dm.StoreNewIdentity(tx, *id)
 		if err != nil {
-			if err == ErrExists {
-				log.Warnf("%s: %v -> skip", id.Uid, err)
-			} else {
-				return err
-			}
+			return err
 		}
 	}
 

--- a/main/migrator.go
+++ b/main/migrator.go
@@ -24,7 +24,7 @@ func MigrateFileToDB(c *Config) error {
 		return err
 	}
 
-	dbManager, err := NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName)
+	dbManager, err := NewSqlDatabaseInfo(c.PostgresDSN, PostgreSqlIdentityTableName, &c.dbParams)
 	if err != nil {
 		return err
 	}

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -154,10 +154,6 @@ func (p *Protocol) GetPrivateKey(uid uuid.UUID) (privateKeyPem []byte, err error
 	return p.keyEncrypter.Decrypt(encryptedPrivateKey)
 }
 
-func (p *Protocol) ExistsPublicKey(uid uuid.UUID) (bool, error) {
-	return p.ctxManager.ExistsPublicKey(uid)
-}
-
 //func (p *Protocol) SetPublicKey(uid uuid.UUID, publicKeyPEM []byte) error {
 //	publicKeyBytes, err := p.PublicKeyPEMToBytes(publicKeyPEM)
 //	if err != nil {
@@ -203,14 +199,6 @@ func (p *Protocol) checkIdentityAttributes(i *Identity) error {
 	}
 
 	return nil
-}
-
-func (p *Protocol) ExistsUuidForPublicKey(publicKeyPEM []byte) (bool, error) {
-	publicKeyBytes, err := p.PublicKeyPEMToBytes(publicKeyPEM)
-	if err != nil {
-		return false, err
-	}
-	return p.ctxManager.ExistsUuidForPublicKey(publicKeyBytes)
 }
 
 func (p *Protocol) GetUuidForPublicKey(publicKeyPEM []byte) (uuid.UUID, error) {
@@ -289,22 +277,14 @@ func (p *Protocol) loadSKIDs() {
 		}
 
 		// look up matching UUID for public key
-		exists, err := p.ExistsUuidForPublicKey(pubKeyPEM)
+		uid, err := p.GetUuidForPublicKey(pubKeyPEM)
 		if err != nil {
-			log.Errorf("%s: %v", kid, err)
-			continue
-		}
-		if !exists {
-			//log.Debugf("%s: public key not found", kid)
+			if err != ErrNotExist {
+				log.Errorf("%s: %v", kid, err)
+			}
 			continue
 		}
 		//log.Debugf("%s: public key certificate match", kid)
-
-		uid, err := p.GetUuidForPublicKey(pubKeyPEM)
-		if err != nil {
-			log.Errorf("%s: %v", kid, err)
-			continue
-		}
 
 		if len(cert.Kid) != SkidLen {
 			log.Errorf("invalid KID length: expected %d, got %d", SkidLen, len(kid))

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -179,7 +179,7 @@ func (p *Protocol) GetAuthToken(uid uuid.UUID) (string, error) {
 	}
 
 	if len(authToken) == 0 {
-		return "", ErrNotExist
+		return "", fmt.Errorf("empty auth token")
 	}
 
 	return authToken, nil

--- a/main/services.go
+++ b/main/services.go
@@ -84,17 +84,11 @@ func (s *COSEService) directUUID() http.HandlerFunc {
 }
 
 func (s *COSEService) handleRequest(w http.ResponseWriter, r *http.Request, uid uuid.UUID) {
-	exists, err := s.ExistsPrivateKey(uid)
-	if err != nil {
-		log.Errorf("%s: %v", uid, err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-	if !exists {
+	authToken, err := s.GetAuthToken(uid)
+	if err == ErrNotExist {
 		h.Error(uid, w, fmt.Errorf("unknown UUID"), http.StatusNotFound)
 		return
 	}
-	authToken, err := s.GetAuthToken(uid)
 	if err != nil {
 		log.Errorf("%s: %v", uid, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)


### PR DESCRIPTION
**Added:**

- configurable DB parameters
  - MaxOpenConns          string               `json:"dbMaxOpenConns" envconfig:"DB_MAX_OPEN_CONNS"`                  // maximum number of open connections to the database
  - MaxIdleConns          string               `json:"dbMaxIdleConns" envconfig:"DB_MAX_IDLE_CONNS"`                  // maximum number of connections in the idle connection pool
  - ConnMaxLifetime       string               `json:"dbConnMaxLifetime" envconfig:"DB_CONN_MAX_LIFETIME"`            // maximum amount of time in minutes a connection may be reused
  - ConnMaxIdleTime       string               `json:"dbConnMaxIdleTime" envconfig:"DB_CONN_MAX_IDLE_TIME"`           // maximum amount of time in minutes a connection may be idle

>  	defaultDbMaxOpenConns    = 10
> 	defaultDbMaxIdleConns    = 10
> 	defaultDbConnMaxLifetime = 10
> 	defaultDbConnMaxIdleTime = 1

**Changed:**

- reduced DB access through replacing "exists" methods with specific errors in case of non-existing identity