### PR TITLE
Run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN \
 FROM scratch
 VOLUME /data
 EXPOSE 8080/tcp
+USER 65534:65534
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder app/main/main cose-client
 ENTRYPOINT ["/cose-client"]


### PR DESCRIPTION
The application used to run as root inside the container. This
commit adds an unprivileged user, that is being used to copy the
configuration and run the executable. This hardens the application
against certain attack vectors. As far as I see, no state
should be kept in /data/ across builds, so this change shouldn't
intruduce problems.