### PR TITLE
UC-159 lower parallelism parameter

### DIFF
--- a/main/config.go
+++ b/main/config.go
@@ -52,7 +52,9 @@ const (
 	defaultKeyDerivationMaxTotalMemory   = 30
 	defaultKeyDerivationParamMemory      = 15
 	defaultKeyDerivationParamTime        = 2
-	defaultKeyDerivationParamParallelism = 4
+	defaultKeyDerivationParamParallelism = 1
+	defaultKeyDerivationKeyLen           = 32
+	defaultKeyDerivationSaltLen          = 16
 
 	defaultRequestLimit        = 10
 	defaultRequestBacklogLimit = 5
@@ -86,6 +88,8 @@ type Config struct {
 	KdParamMemMiB             uint32 `json:"kdParamMemMiB" envconfig:"KD_PARAM_MEM_MIB"`                    // memory parameter for key derivation, specifies the size of the memory in MiB
 	KdParamTime               uint32 `json:"kdParamTime" envconfig:"KD_PARAM_TIME"`                         // time parameter for key derivation, specifies the number of passes over the memory
 	KdParamParallelism        uint8  `json:"kdParamParallelism" envconfig:"KD_PARAM_PARALLELISM"`           // parallelism (threads) parameter for key derivation, specifies the number of threads and can be adjusted to the number of available CPUs
+	KdParamKeyLen             uint32 `json:"kdParamKeyLen" envconfig:"KD_PARAM_KEY_LEN"`                    // key length parameter for key derivation, specifies the length of the resulting key in bytes
+	KdParamSaltLen            uint32 `json:"kdParamSaltLen" envconfig:"KD_PARAM_SALT_LEN"`                  // salt length parameter for key derivation, specifies the length of the random salt in bytes
 	RequestLimit              int    `json:"requestLimit" envconfig:"REQUEST_LIMIT"`                        // limits number of currently processed (incoming) requests at a time
 	RequestBacklogLimit       int    `json:"requestBacklogLimit" envconfig:"REQUEST_BACKLOG_LIMIT"`         // backlog for holding a finite number of pending requests
 	serverTLSCertFingerprints map[string][32]byte
@@ -257,6 +261,14 @@ func (c *Config) setKeyDerivationParams() {
 
 	if c.KdParamParallelism == 0 {
 		c.KdParamParallelism = defaultKeyDerivationParamParallelism
+	}
+
+	if c.KdParamKeyLen == 0 {
+		c.KdParamKeyLen = defaultKeyDerivationKeyLen
+	}
+
+	if c.KdParamSaltLen == 0 {
+		c.KdParamSaltLen = defaultKeyDerivationSaltLen
 	}
 }
 

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"requestLimit":0,"requestBacklogLimit":0}`
+const expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"requestLimit":0,"requestBacklogLimit":0}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/password-hashing/argon2id_key_derivator.go
+++ b/main/password-hashing/argon2id_key_derivator.go
@@ -16,9 +16,12 @@ import (
 )
 
 const (
-	KeyLen            = 24
-	SaltLen           = 16
-	stdEncodingFormat = "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s"
+	DefaultMemory      uint32 = 15
+	DefaultTime        uint32 = 2
+	DefaultParallelism uint8  = 1
+	DefaultKeyLen      uint32 = 32
+	DefaultSaltLen     uint32 = 16
+	stdEncodingFormat         = "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s"
 )
 
 type Argon2idKeyDerivator struct {
@@ -39,23 +42,39 @@ type Argon2idParams struct {
 	SaltLen uint32 // the length of the random salt in byte
 }
 
-func GetArgon2idParams(memMiB, time uint32, threads uint8) *Argon2idParams {
+func GetArgon2idParams(memMiB, time uint32, threads uint8, keyLen, saltLen uint32) *Argon2idParams {
+	if memMiB == 0 {
+		memMiB = DefaultMemory
+	}
+
+	if time == 0 {
+		time = DefaultTime
+	}
+
+	if threads == 0 {
+		threads = DefaultParallelism
+	}
+
+	if keyLen == 0 {
+		keyLen = DefaultKeyLen
+	}
+
+	if saltLen == 0 {
+		saltLen = DefaultSaltLen
+	}
+
 	return &Argon2idParams{
 		Memory:  memMiB * 1024,
 		Time:    time,
 		Threads: threads,
-		KeyLen:  KeyLen,
-		SaltLen: SaltLen,
+		KeyLen:  keyLen,
+		SaltLen: saltLen,
 	}
 }
 
 func (kd *Argon2idKeyDerivator) DefaultParams() *Argon2idParams {
 	// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
-	memMiB := uint32(15)
-	time := uint32(2)
-	threads := uint8(4)
-
-	return GetArgon2idParams(memMiB, time, threads)
+	return GetArgon2idParams(DefaultMemory, DefaultTime, DefaultParallelism, DefaultKeyLen, DefaultSaltLen)
 }
 
 // GeneratePasswordHash derives a key from the password, salt, and cost parameters using Argon2id

--- a/main/password-hashing/argon2id_key_derivator_test.go
+++ b/main/password-hashing/argon2id_key_derivator_test.go
@@ -15,7 +15,7 @@ import (
 func TestArgon2idKeyDerivator(t *testing.T) {
 	testAuth := generateRandomAuth()
 
-	kd := NewArgon2idKeyDerivator(15)
+	kd := NewArgon2idKeyDerivator(DefaultMemory)
 	params := kd.DefaultParams()
 
 	pw, err := kd.GeneratePasswordHash(context.Background(), testAuth, params)
@@ -131,7 +131,7 @@ func BenchmarkArgon2idKeyDerivator_TweakParams(b *testing.B) {
 	threads := uint8(4)
 
 	kd := &Argon2idKeyDerivator{}
-	params := GetArgon2idParams(memMiB, time, threads)
+	params := GetArgon2idParams(memMiB, time, threads, DefaultKeyLen, DefaultSaltLen)
 	b.Log(argon2idParams(params))
 
 	auth := make([]byte, 32)

--- a/main/password-hashing/argon2id_key_derivator_test.go
+++ b/main/password-hashing/argon2id_key_derivator_test.go
@@ -75,6 +75,14 @@ func TestDecode(t *testing.T) {
 	asserter.Equal(hash, testHash)
 }
 
+func TestGetArgon2idParams(t *testing.T) {
+	kd := &Argon2idKeyDerivator{}
+	defaultParams := kd.DefaultParams()
+	params := GetArgon2idParams(0, 0, 0, 0, 0)
+
+	assert.Equal(t, *defaultParams, *params)
+}
+
 func BenchmarkArgon2idKeyDerivator_Default(b *testing.B) {
 	kd := &Argon2idKeyDerivator{}
 	params := kd.DefaultParams()

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -41,11 +41,9 @@ type Protocol struct {
 	uidCache      *sync.Map // {<pub>: <uid>}
 }
 
-// Ensure Protocol implements the StorageManager interface
-var _ StorageManager = (*Protocol)(nil)
-
 func NewProtocol(storageManager StorageManager, conf *Config) *Protocol {
-	argon2idParams := pw.GetArgon2idParams(conf.KdParamMemMiB, conf.KdParamTime, conf.KdParamParallelism)
+	argon2idParams := pw.GetArgon2idParams(conf.KdParamMemMiB, conf.KdParamTime, conf.KdParamParallelism,
+		conf.KdParamKeyLen, conf.KdParamSaltLen)
 	params, _ := json.Marshal(argon2idParams)
 	log.Debugf("initialize argon2id key derivation with parameters %s", params)
 


### PR DESCRIPTION
**Changed:**

- lower default key derivation parameter `parallelism`to 1
-  make key derivation parameter `key length` configurable
    - json: `kdParamKeyLen`   
    - envconfig: `KD_PARAM_KEY_LEN`

-  make key derivation parameter `salt length` configurable
    - json: `kdParamSaltLen`  
    - envconfig: `KD_PARAM_SALT_LEN`