### PR TITLE
UC-162 auth cache

### DIFF
--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -206,10 +206,6 @@ func mockGetSKIDReturnsErr(uuid.UUID) ([]byte, error) {
 	return nil, test.Error
 }
 
-func mockSign(uuid.UUID, []byte) ([]byte, error) {
-	return make([]byte, 64), nil
-}
-
 func mockSignReturnsError(uuid.UUID, []byte) ([]byte, error) {
 	return nil, test.Error
 }

--- a/main/http-server/identity_registerer.go
+++ b/main/http-server/identity_registerer.go
@@ -1,7 +1,6 @@
 package http_server
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,7 +22,7 @@ type RegistrationPayload struct {
 	Pwd string    `json:"password"`
 }
 
-type InitializeIdentity func(ctx context.Context, uid uuid.UUID) (csr []byte, pw string, err error)
+type InitializeIdentity func(uid uuid.UUID) (csr []byte, pw string, err error)
 
 func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,7 @@ func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFu
 
 		uid := idPayload.Uid
 
-		csr, auth, err := initialize(r.Context(), uid)
+		csr, auth, err := initialize(uid)
 		if err != nil {
 			switch err {
 			case ErrAlreadyInitialized:

--- a/main/identity_handler.go
+++ b/main/identity_handler.go
@@ -38,7 +38,7 @@ type IdentityHandler struct {
 	subjectOrganization string
 }
 
-func (i *IdentityHandler) InitIdentity(ctx context.Context, uid uuid.UUID) (csrPEM []byte, auth string, err error) {
+func (i *IdentityHandler) InitIdentity(uid uuid.UUID) (csrPEM []byte, auth string, err error) {
 	err = i.Protocol.IsReady()
 	if err != nil {
 		return nil, "", err
@@ -79,15 +79,10 @@ func (i *IdentityHandler) InitIdentity(ctx context.Context, uid uuid.UUID) (csrP
 		return nil, "", err
 	}
 
-	pwHash, err := i.Protocol.PwHasher.GeneratePasswordHash(ctx, pw, i.Protocol.PwHasherParams)
-	if err != nil {
-		return nil, "", err
-	}
-
 	identity := Identity{
 		Uid:          uid,
 		PublicKeyPEM: pubKeyPEM,
-		Auth:         pwHash,
+		Auth:         pw,
 	}
 
 	ctxForTransaction, cancel := context.WithCancel(context.Background())

--- a/main/identity_handler_test.go
+++ b/main/identity_handler_test.go
@@ -43,7 +43,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 		subjectOrganization: "test GmbH",
 	}
 
-	csrPEM, auth, err := idHandler.InitIdentity(context.Background(), test.Uuid)
+	csrPEM, auth, err := idHandler.InitIdentity(test.Uuid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 		t.Error("auth token returned by InitIdentity not equal to registered auth token")
 	}
 
-	ok, err := p.PwHasher.CheckPassword(context.Background(), client.Auth, initializedIdentity.Auth)
+	ok, err := p.pwHasher.CheckPassword(context.Background(), initializedIdentity.Auth, client.Auth)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,12 +141,12 @@ func TestIdentityHandler_InitIdentityBad_ErrAlreadyInitialized(t *testing.T) {
 		subjectOrganization: "test GmbH",
 	}
 
-	_, _, err = idHandler.InitIdentity(context.Background(), test.Uuid)
+	_, _, err = idHandler.InitIdentity(test.Uuid)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, err = idHandler.InitIdentity(context.Background(), test.Uuid)
+	_, _, err = idHandler.InitIdentity(test.Uuid)
 	if err != h.ErrAlreadyInitialized {
 		t.Errorf("unexpected error: %v, expected: %v", err, h.ErrAlreadyInitialized)
 	}
@@ -174,7 +174,7 @@ func TestIdentityHandler_InitIdentityBad_ErrUnknown(t *testing.T) {
 		subjectOrganization: "test GmbH",
 	}
 
-	_, _, err := idHandler.InitIdentity(context.Background(), test.Uuid)
+	_, _, err := idHandler.InitIdentity(test.Uuid)
 	if err != h.ErrUnknown {
 		t.Errorf("unexpected error: %v, expected: %v", err, h.ErrUnknown)
 	}
@@ -212,7 +212,7 @@ func TestIdentityHandler_InitIdentity_BadRegistration(t *testing.T) {
 		subjectOrganization: "test GmbH",
 	}
 
-	_, _, err = idHandler.InitIdentity(context.Background(), test.Uuid)
+	_, _, err = idHandler.InitIdentity(test.Uuid)
 	if err != test.Error {
 		t.Errorf("unexpected error: %v, expected: %v", err, test.Error)
 	}
@@ -250,7 +250,7 @@ func TestIdentityHandler_CreateCSR(t *testing.T) {
 		subjectOrganization: "test GmbH",
 	}
 
-	_, _, err = idHandler.InitIdentity(context.Background(), test.Uuid)
+	_, _, err = idHandler.InitIdentity(test.Uuid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -184,9 +184,8 @@ func main() {
 	}
 
 	service := &COSEService{
-		GetIdentity: protocol.GetIdentity,
-		CheckAuth:   protocol.PwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: protocol.CheckAuth,
+		Sign:      coseSigner.Sign,
 	}
 
 	// set up HTTP server

--- a/main/main.go
+++ b/main/main.go
@@ -209,10 +209,10 @@ func main() {
 
 	// set up endpoints for COSE signing (UUID as URL parameter)
 	directUuidEndpoint := path.Join(h.UUIDPath, h.CBORPath) // /<uuid>/cbor
-	httpServer.Router.Post(directUuidEndpoint, service.handleRequest(getUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes)))
+	httpServer.Router.Post(directUuidEndpoint, service.handleRequest(h.GetUUID, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes)))
 
 	directUuidHashEndpoint := path.Join(directUuidEndpoint, h.HashEndpoint) // /<uuid>/cbor/hash
-	httpServer.Router.Post(directUuidHashEndpoint, service.handleRequest(getUUIDFromURL, GetHashFromHashRequest()))
+	httpServer.Router.Post(directUuidHashEndpoint, service.handleRequest(h.GetUUID, GetHashFromHashRequest()))
 
 	// set up endpoints for liveness and readiness checks
 	httpServer.Router.Get("/healthz", h.Healthz(serverID))

--- a/main/password-hashing/argon2id_key_derivator.go
+++ b/main/password-hashing/argon2id_key_derivator.go
@@ -100,7 +100,7 @@ func (kd *Argon2idKeyDerivator) GeneratePasswordHash(ctx context.Context, pw str
 	return encodePasswordHash(params, salt, hash), nil
 }
 
-func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwToCheck string, pwHash string) (bool, error) {
+func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwHash, pwToCheck string) (bool, error) {
 	p, salt, hash, err := decodePasswordHash(pwHash)
 	if err != nil {
 		return false, fmt.Errorf("failed to decode argon2id password hash: %v", err)

--- a/main/password-hashing/argon2id_key_derivator_test.go
+++ b/main/password-hashing/argon2id_key_derivator_test.go
@@ -27,7 +27,7 @@ func TestArgon2idKeyDerivator(t *testing.T) {
 	assert.Equal(t, int(params.SaltLen), len(salt))
 	assert.Equal(t, *params, *decodedParams)
 
-	ok, err := kd.CheckPassword(context.Background(), testAuth, pw)
+	ok, err := kd.CheckPassword(context.Background(), pw, testAuth)
 	require.NoError(t, err)
 	assert.True(t, ok)
 }

--- a/main/protocol_test.go
+++ b/main/protocol_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
 
+	pw "github.com/ubirch/ubirch-cose-client-go/main/password-hashing"
 	test "github.com/ubirch/ubirch-cose-client-go/main/tests"
 )
 
@@ -29,11 +33,14 @@ func TestProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	kd := &pw.Argon2idKeyDerivator{}
+
 	p := &Protocol{
 		StorageManager: &mockStorageMngr{},
-
-		identityCache: &sync.Map{},
-		uidCache:      &sync.Map{},
+		pwHasher:       kd,
+		pwHasherParams: kd.DefaultParams(),
+		authCache:      &sync.Map{},
+		uidCache:       &sync.Map{},
 	}
 
 	testIdentity := Identity{
@@ -44,73 +51,46 @@ func TestProtocol(t *testing.T) {
 
 	// check not exists
 	_, err = p.GetIdentity(testIdentity.Uid)
-	if err != ErrNotExist {
-		t.Error("GetIdentity did not return ErrNotExist")
-	}
+	assert.Equal(t, ErrNotExist, err)
 
 	exists, err := p.IsInitialized(testIdentity.Uid)
-	if err != nil {
-		t.Error(err)
-	}
-	if exists {
-		t.Error("IsInitialized returned TRUE")
-	}
+	require.NoError(t, err)
+	assert.False(t, exists)
 
 	_, err = p.GetUuidForPublicKey(testIdentity.PublicKeyPEM)
-	if err != ErrNotExist {
-		t.Error("GetUuidForPublicKey did not return ErrNotExist")
-	}
+	assert.Equal(t, ErrNotExist, err)
 
 	// store identity
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	tx, err := p.StartTransaction(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = p.StoreNewIdentity(tx, testIdentity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = p.CommitTransaction(tx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// check exists
 	exists, err = p.IsInitialized(testIdentity.Uid)
-	if err != nil {
-		t.Error(err)
-	}
-	if !exists {
-		t.Error("IsInitialized returned FALSE")
-	}
+	require.NoError(t, err)
+	assert.True(t, exists)
 
 	storedIdentity, err := p.GetIdentity(testIdentity.Uid)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(storedIdentity.Uid[:], testIdentity.Uid[:]) {
-		t.Error("GetIdentity returned unexpected Uid value")
-	}
-	if !bytes.Equal(storedIdentity.PublicKeyPEM, testIdentity.PublicKeyPEM) {
-		t.Error("GetIdentity returned unexpected PublicKeyPEM value")
-	}
-	if storedIdentity.Auth != testIdentity.Auth {
-		t.Error("GetIdentity returned unexpected Auth value")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, testIdentity.Uid, storedIdentity.Uid)
+	assert.Equal(t, testIdentity.PublicKeyPEM, storedIdentity.PublicKeyPEM)
 
 	storedUid, err := p.GetUuidForPublicKey(testIdentity.PublicKeyPEM)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(storedUid[:], testIdentity.Uid[:]) {
-		t.Errorf("GetUuidForPublicKey returned unexpected value: %s, expected: %s", storedUid[:], testIdentity.Uid[:])
-	}
+	require.NoError(t, err)
+	assert.Equal(t, testIdentity.Uid, storedUid)
+
+	ok, found, err := p.CheckAuth(ctx, testIdentity.Uid, testIdentity.Auth)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, ok)
 }
 
 func TestProtocolLoad(t *testing.T) {
@@ -122,11 +102,15 @@ func TestProtocolLoad(t *testing.T) {
 	}
 	defer cleanUpDB(t, dm)
 
+	kd := &pw.Argon2idKeyDerivator{}
+
 	p := &Protocol{
 		StorageManager: dm,
+		pwHasher:       kd,
+		pwHasherParams: kd.DefaultParams(),
 
-		identityCache: &sync.Map{},
-		uidCache:      &sync.Map{},
+		authCache: &sync.Map{},
+		uidCache:  &sync.Map{},
 	}
 
 	// generate identities
@@ -153,7 +137,7 @@ func TestProtocolLoad(t *testing.T) {
 	for _, testId := range testIdentities {
 		wg.Add(1)
 		go func(id *Identity) {
-			err := checkIdentity(p, id, wg)
+			err := checkIdentity(p, id, protocolCheckAuth, wg)
 			if err != nil {
 				t.Errorf("%s: %v", id.Uid, err)
 			}
@@ -292,7 +276,7 @@ func TestProtocol_Cache(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			err := checkIdentity(p, &testIdentity, wg)
+			err := checkIdentity(p, &testIdentity, protocolCheckAuth, wg)
 			if err != nil {
 				t.Errorf("%s: %v", testIdentity.Uid, err)
 			}
@@ -315,6 +299,19 @@ func TestProtocol_GetUuidForPublicKey_BadPublicKey(t *testing.T) {
 	if err == nil {
 		t.Error("GetUuidForPublicKey did not return error for invalid public key")
 	}
+}
+
+func protocolCheckAuth(auth, authToCheck string) error {
+	pwHasher := &pw.Argon2idKeyDerivator{}
+
+	ok, err := pwHasher.CheckPassword(context.Background(), auth, authToCheck)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("protocolCheckAuth failed: %s != %s", auth, authToCheck)
+	}
+	return nil
 }
 
 type mockStorageMngr struct {

--- a/main/services.go
+++ b/main/services.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi"
 	"github.com/google/uuid"
 
 	log "github.com/sirupsen/logrus"
@@ -98,16 +97,6 @@ func (s *COSEService) handleRequest(getUUID GetUUID, getPayloadAndHash GetPayloa
 			h.SendResponse(w, resp)
 		}
 	}
-}
-
-// getUUIDFromURL returns the UUID parameter from the request URL
-func getUUIDFromURL(r *http.Request) (uuid.UUID, error) {
-	uuidParam := chi.URLParam(r, h.UUIDKey)
-	uid, err := uuid.Parse(uuidParam)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("invalid UUID: \"%s\": %v", uuidParam, err)
-	}
-	return uid, nil
 }
 
 func GetHashFromHashRequest() GetPayloadAndHash {

--- a/main/services_test.go
+++ b/main/services_test.go
@@ -12,32 +12,13 @@ import (
 	"github.com/google/uuid"
 
 	h "github.com/ubirch/ubirch-cose-client-go/main/http-server"
-	pw "github.com/ubirch/ubirch-cose-client-go/main/password-hashing"
 	test "github.com/ubirch/ubirch-cose-client-go/main/tests"
 )
 
 func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -45,7 +26,6 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -55,27 +35,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHashHex := "76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881f"
@@ -84,7 +46,6 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHashHex))
 	r.Header.Set("Content-Type", h.TextType)
 	r.Header.Set("Content-Transfer-Encoding", HexEncoding)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -94,27 +55,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHashBytes, _ := hex.DecodeString("76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881f")
@@ -122,7 +65,6 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(testHashBytes))
 	r.Header.Set("Content-Type", h.BinType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -132,27 +74,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -160,9 +84,8 @@ func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
-	testCOSEService.handleRequest(getUUIDFromURL, GetHashFromHashRequest())(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURLBad, GetHashFromHashRequest())(w, r)
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusNotFound)
@@ -170,27 +93,9 @@ func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  uuid.New(),
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuthNotFound,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -198,7 +103,6 @@ func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -207,15 +111,10 @@ func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
 	}
 }
 
-func TestCOSEService_HandleRequest_CantGetIdentity(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 	testCOSEService := &COSEService{
-		GetIdentity: mockGetIdentityReturnsErr,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuthBad,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -223,7 +122,6 @@ func TestCOSEService_HandleRequest_CantGetIdentity(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -233,27 +131,9 @@ func TestCOSEService_HandleRequest_CantGetIdentity(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_BadAuth(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuthNotOk,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -261,7 +141,6 @@ func TestCOSEService_HandleRequest_BadAuth(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, "12345")
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -271,27 +150,9 @@ func TestCOSEService_HandleRequest_BadAuth(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g"
@@ -299,7 +160,6 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -309,27 +169,9 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHashHex := "76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881ff"
@@ -338,7 +180,6 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHashHex))
 	r.Header.Set("Content-Type", h.TextType)
 	r.Header.Set("Content-Transfer-Encoding", HexEncoding)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -348,27 +189,9 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -376,7 +199,6 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
 	r.Header.Set("Content-Type", "wrong content type")
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -386,27 +208,9 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	tooShortHash := "x/Ef/8VDEjvybn2gvxGeiA=="
@@ -414,7 +218,6 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tooShortHash))
 	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
 	testCOSEService.handleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
@@ -424,35 +227,16 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(payloadJSON)))
 	r.Header.Set("Content-Type", h.JSONType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
-	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes))(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
@@ -460,37 +244,16 @@ func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
-
-	badJSON := "absolutely not a json"
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(badJSON)))
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(payloadJSON)))
 	r.Header.Set("Content-Type", h.JSONType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
-	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes))(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
@@ -498,27 +261,9 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 }
 
 func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	testCBOR, _ := hex.DecodeString("a164746573746568656c6c6f")
@@ -526,81 +271,42 @@ func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(testCBOR))
 	r.Header.Set("Content-Type", h.CBORType)
-	r.Header.Set(h.AuthHeader, test.Auth)
 
-	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes))(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
 	}
 }
 
-func TestCOSEService_HandleRequest_DataRequest_BadCBOR(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
+func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
-	r.Header.Set("Content-Type", h.CBORType)
-	r.Header.Set(h.AuthHeader, test.Auth)
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(payloadJSON)))
+	r.Header.Set("Content-Type", h.TextType)
 
-	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes))(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
 	}
 }
 
-func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
-	coseSigner, err := NewCoseSigner(mockSign, mockGetSKID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pwHasher := pw.NewArgon2idKeyDerivator(1)
-	params := &pw.Argon2idParams{Memory: 1, Time: 1, Threads: 8, KeyLen: 24, SaltLen: 16}
-	pwHash, err := pwHasher.GeneratePasswordHash(context.Background(), test.Auth, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	storageMngr := mockStorageMngr{id: Identity{
-		Uid:  test.Uuid,
-		Auth: pwHash,
-	}}
-
+func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 	testCOSEService := &COSEService{
-		GetIdentity: storageMngr.GetIdentity,
-		CheckAuth:   pwHasher.CheckPassword,
-		Sign:        coseSigner.Sign,
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(payloadJSON)))
-	r.Header.Set("Content-Type", h.TextType)
-	r.Header.Set(h.AuthHeader, test.Auth)
+	r.Header.Set("Content-Type", h.JSONType)
 
-	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(coseSigner.GetCBORFromJSON, coseSigner.GetSigStructBytes))(w, r)
+	testCOSEService.handleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
@@ -639,10 +345,50 @@ func TestSendResponse(t *testing.T) {
 	}
 }
 
+func mockCheckAuth(context.Context, uuid.UUID, string) (bool, bool, error) {
+	return true, true, nil
+}
+
+func mockCheckAuthBad(context.Context, uuid.UUID, string) (bool, bool, error) {
+	return false, false, test.Error
+}
+
+func mockCheckAuthNotFound(context.Context, uuid.UUID, string) (bool, bool, error) {
+	return false, false, nil
+}
+
+func mockCheckAuthNotOk(context.Context, uuid.UUID, string) (bool, bool, error) {
+	return false, true, nil
+}
+
+func mockSign(HTTPRequest) h.HTTPResponse {
+	return h.HTTPResponse{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {h.BinType}},
+		Content:    []byte("mock"),
+	}
+}
+
 func mockGetUUIDFromURL(*http.Request) (uuid.UUID, error) {
 	return test.Uuid, nil
 }
 
-func mockGetIdentityReturnsErr(uuid.UUID) (Identity, error) {
-	return Identity{}, test.Error
+func mockGetUUIDFromURLBad(*http.Request) (uuid.UUID, error) {
+	return uuid.Nil, test.Error
+}
+
+func mockGetCBORFromJSON([]byte) ([]byte, error) {
+	return []byte("mock CBOR"), nil
+}
+
+func mockGetCBORFromJSONBad([]byte) ([]byte, error) {
+	return nil, test.Error
+}
+
+func mockGetSigStructBytes([]byte) ([]byte, error) {
+	return []byte("mock signature struct bytes"), nil
+}
+
+func mockGetSigStructBytesBad([]byte) ([]byte, error) {
+	return nil, test.Error
 }

--- a/main/skid_handler_test.go
+++ b/main/skid_handler_test.go
@@ -24,8 +24,8 @@ func TestNewSkidHandler(t *testing.T) {
 	p := &Protocol{
 		StorageManager: &mockStorageMngr{},
 
-		identityCache: &sync.Map{},
-		uidCache:      &sync.Map{},
+		authCache: &sync.Map{},
+		uidCache:  &sync.Map{},
 	}
 
 	s := NewSkidHandler(mockGetCertificateList, p.mockGetUuidForPublicKey, c.EncodePublicKey, false)
@@ -81,8 +81,8 @@ func TestSkidHandler_LoadSKIDs(t *testing.T) {
 	p := &Protocol{
 		StorageManager: &mockStorageMngr{},
 
-		identityCache: &sync.Map{},
-		uidCache:      &sync.Map{},
+		authCache: &sync.Map{},
+		uidCache:  &sync.Map{},
 	}
 
 	s := &SkidHandler{
@@ -169,8 +169,8 @@ func TestSkidHandler_LoadSKIDs_CertificateValidity(t *testing.T) {
 	p := &Protocol{
 		StorageManager: &mockStorageMngr{},
 
-		identityCache: &sync.Map{},
-		uidCache:      &sync.Map{},
+		authCache: &sync.Map{},
+		uidCache:  &sync.Map{},
 	}
 
 	s := NewSkidHandler(mockGetCertificateList, p.mockGetUuidForPublicKey, c.EncodePublicKey, false)


### PR DESCRIPTION
**Changed:**

- cache token after successful authentication instead of password hash
    _This change enhances performance since performing key derivation for each incoming request is expensive._