### PR TITLE
UC-160 pw hash update

### DIFF
--- a/main/config.go
+++ b/main/config.go
@@ -49,7 +49,6 @@ const (
 
 	defaultPKCS11Module = "libcs_pkcs11_R3.so"
 
-	defaultKeyDerivationMaxTotalMemory   = 30
 	defaultKeyDerivationParamMemory      = 15
 	defaultKeyDerivationParamTime        = 2
 	defaultKeyDerivationParamParallelism = 1
@@ -90,6 +89,7 @@ type Config struct {
 	KdParamParallelism        uint8  `json:"kdParamParallelism" envconfig:"KD_PARAM_PARALLELISM"`           // parallelism (threads) parameter for key derivation, specifies the number of threads and can be adjusted to the number of available CPUs
 	KdParamKeyLen             uint32 `json:"kdParamKeyLen" envconfig:"KD_PARAM_KEY_LEN"`                    // key length parameter for key derivation, specifies the length of the resulting key in bytes
 	KdParamSaltLen            uint32 `json:"kdParamSaltLen" envconfig:"KD_PARAM_SALT_LEN"`                  // salt length parameter for key derivation, specifies the length of the random salt in bytes
+	KdUpdateParams            bool   `json:"kdUpdateParams" envconfig:"KD_UPDATE_PARAMS"`                   // update key derivation parameters of already existing password hashes
 	RequestLimit              int    `json:"requestLimit" envconfig:"REQUEST_LIMIT"`                        // limits number of currently processed (incoming) requests at a time
 	RequestBacklogLimit       int    `json:"requestBacklogLimit" envconfig:"REQUEST_BACKLOG_LIMIT"`         // backlog for holding a finite number of pending requests
 	serverTLSCertFingerprints map[string][32]byte
@@ -247,10 +247,6 @@ func (c *Config) setDefaultRequestLimits() {
 }
 
 func (c *Config) setKeyDerivationParams() {
-	if c.KdMaxTotalMemMiB == 0 {
-		c.KdMaxTotalMemMiB = defaultKeyDerivationMaxTotalMemory
-	}
-
 	if c.KdParamMemMiB == 0 {
 		c.KdParamMemMiB = defaultKeyDerivationParamMemory
 	}

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"requestLimit":0,"requestBacklogLimit":0}`
+const expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"requestLimit":0,"requestBacklogLimit":0}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/identity_handler.go
+++ b/main/identity_handler.go
@@ -93,7 +93,7 @@ func (i *IdentityHandler) InitIdentity(uid uuid.UUID) (csrPEM []byte, auth strin
 		return nil, "", err
 	}
 
-	err = i.Protocol.StoreNewIdentity(tx, identity)
+	err = i.Protocol.StoreIdentity(tx, identity)
 	if err != nil {
 		return nil, "", fmt.Errorf("could not store new identity: %v", err)
 	}
@@ -103,7 +103,7 @@ func (i *IdentityHandler) InitIdentity(uid uuid.UUID) (csrPEM []byte, auth strin
 		return nil, "", err
 	}
 
-	err = i.Protocol.CommitTransaction(tx)
+	err = tx.Commit()
 	if err != nil {
 		return nil, "", fmt.Errorf("commiting transaction to store new identity failed after successful registration at certify-api: %v", err)
 	}

--- a/main/identity_handler_test.go
+++ b/main/identity_handler_test.go
@@ -24,12 +24,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 
@@ -61,7 +56,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 		t.Error(err)
 	}
 
-	initializedIdentity, err := p.GetIdentity(test.Uuid)
+	initializedIdentity, err := p.LoadIdentity(test.Uuid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +83,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 		t.Error("auth token returned by InitIdentity not equal to registered auth token")
 	}
 
-	ok, err := p.pwHasher.CheckPassword(context.Background(), initializedIdentity.Auth, client.Auth)
+	_, ok, err := p.pwHasher.CheckPassword(context.Background(), initializedIdentity.Auth, client.Auth)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,12 +119,7 @@ func TestIdentityHandler_InitIdentityBad_ErrAlreadyInitialized(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 
@@ -157,12 +147,7 @@ func TestIdentityHandler_InitIdentityBad_ErrUnknown(t *testing.T) {
 		Keystore: &test.MockKeystorer{},
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 
@@ -179,7 +164,7 @@ func TestIdentityHandler_InitIdentityBad_ErrUnknown(t *testing.T) {
 		t.Errorf("unexpected error: %v, expected: %v", err, h.ErrUnknown)
 	}
 
-	_, err = p.GetIdentity(test.Uuid)
+	_, err = p.LoadIdentity(test.Uuid)
 	if err != ErrNotExist {
 		t.Errorf("unexpected error: %v, expected: %v", err, ErrNotExist)
 	}
@@ -195,12 +180,7 @@ func TestIdentityHandler_InitIdentity_BadRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 
@@ -217,7 +197,7 @@ func TestIdentityHandler_InitIdentity_BadRegistration(t *testing.T) {
 		t.Errorf("unexpected error: %v, expected: %v", err, test.Error)
 	}
 
-	_, err = p.GetIdentity(test.Uuid)
+	_, err = p.LoadIdentity(test.Uuid)
 	if err != ErrNotExist {
 		t.Errorf("unexpected error: %v, expected: %v", err, ErrNotExist)
 	}
@@ -233,12 +213,7 @@ func TestIdentityHandler_CreateCSR(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 
@@ -273,7 +248,7 @@ func TestIdentityHandler_CreateCSR(t *testing.T) {
 		t.Error(err)
 	}
 
-	initializedIdentity, err := p.GetIdentity(test.Uuid)
+	initializedIdentity, err := p.LoadIdentity(test.Uuid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,12 +268,7 @@ func TestIdentityHandler_CreateCSR_Unknown(t *testing.T) {
 		Keystore: &test.MockKeystorer{},
 	}
 
-	conf := &Config{
-		KdMaxTotalMemMiB:   4,
-		KdParamMemMiB:      2,
-		KdParamTime:        1,
-		KdParamParallelism: 2,
-	}
+	conf := &Config{}
 
 	p := NewProtocol(&mockStorageMngr{}, conf)
 

--- a/main/password-hashing/argon2id_key_derivator.go
+++ b/main/password-hashing/argon2id_key_derivator.go
@@ -25,12 +25,22 @@ const (
 )
 
 type Argon2idKeyDerivator struct {
-	sem *semaphore.Weighted
+	sem          *semaphore.Weighted
+	Params       *Argon2idParams
+	updateParams bool
 }
 
-func NewArgon2idKeyDerivator(maxTotalMemMiB uint32) *Argon2idKeyDerivator {
+func NewArgon2idKeyDerivator(maxTotalMemMiB uint32, params *Argon2idParams, updateParams bool) *Argon2idKeyDerivator {
+	var s *semaphore.Weighted = nil
+
+	if maxTotalMemMiB != 0 {
+		s = semaphore.NewWeighted(int64(maxTotalMemMiB) * 1024)
+	}
+
 	return &Argon2idKeyDerivator{
-		sem: semaphore.NewWeighted(int64(maxTotalMemMiB) * 1024),
+		sem:          s,
+		Params:       params,
+		updateParams: updateParams,
 	}
 }
 
@@ -72,7 +82,7 @@ func GetArgon2idParams(memMiB, time uint32, threads uint8, keyLen, saltLen uint3
 	}
 }
 
-func (kd *Argon2idKeyDerivator) DefaultParams() *Argon2idParams {
+func GetDefaultArgon2idParams() *Argon2idParams {
 	// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
 	return GetArgon2idParams(DefaultMemory, DefaultTime, DefaultParallelism, DefaultKeyLen, DefaultSaltLen)
 }
@@ -80,30 +90,34 @@ func (kd *Argon2idKeyDerivator) DefaultParams() *Argon2idParams {
 // GeneratePasswordHash derives a key from the password, salt, and cost parameters using Argon2id
 // returning the standard encoded representation of the hashed password
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-argon2-03
-func (kd *Argon2idKeyDerivator) GeneratePasswordHash(ctx context.Context, pw string, params *Argon2idParams) (string, error) {
-	salt := make([]byte, params.SaltLen)
+func (kd *Argon2idKeyDerivator) GeneratePasswordHash(ctx context.Context, pw string) (string, error) {
+	if kd.Params == nil {
+		return "", fmt.Errorf("Argon2idParams for key derivation not set")
+	}
+
+	salt := make([]byte, kd.Params.SaltLen)
 	_, err := rand.Read(salt)
 	if err != nil {
 		return "", err
 	}
 
 	if kd.sem != nil {
-		err = kd.sem.Acquire(ctx, int64(params.Memory))
+		err = kd.sem.Acquire(ctx, int64(kd.Params.Memory))
 		if err != nil {
 			return "", fmt.Errorf("failed to acquire semaphore for key derivation: %v", err)
 		}
-		defer kd.sem.Release(int64(params.Memory))
+		defer kd.sem.Release(int64(kd.Params.Memory))
 	}
 
-	hash := argon2.IDKey([]byte(pw), salt, params.Time, params.Memory, params.Threads, params.KeyLen)
+	hash := argon2.IDKey([]byte(pw), salt, kd.Params.Time, kd.Params.Memory, kd.Params.Threads, kd.Params.KeyLen)
 
-	return encodePasswordHash(params, salt, hash), nil
+	return encodePasswordHash(kd.Params, salt, hash), nil
 }
 
-func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwHash, pwToCheck string) (bool, error) {
+func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwHash, pwToCheck string) (needsUpdate, ok bool, err error) {
 	p, salt, hash, err := decodePasswordHash(pwHash)
 	if err != nil {
-		return false, fmt.Errorf("failed to decode argon2id password hash: %v", err)
+		return false, false, fmt.Errorf("failed to decode argon2id password hash: %v", err)
 	}
 
 	if kd.sem != nil {
@@ -111,7 +125,7 @@ func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwHash, pwToC
 		defer timerWait.ObserveDuration()
 		err = kd.sem.Acquire(ctx, int64(p.Memory))
 		if err != nil {
-			return false, fmt.Errorf("failed to acquire semaphore for key derivation: %v", err)
+			return false, false, fmt.Errorf("failed to acquire semaphore for key derivation: %v", err)
 		}
 		defer kd.sem.Release(int64(p.Memory))
 	}
@@ -120,7 +134,17 @@ func (kd *Argon2idKeyDerivator) CheckPassword(ctx context.Context, pwHash, pwToC
 	defer timerAuth.ObserveDuration()
 	hashToCheck := argon2.IDKey([]byte(pwToCheck), salt, p.Time, p.Memory, p.Threads, p.KeyLen)
 
-	return bytes.Equal(hash, hashToCheck), nil
+	if !bytes.Equal(hash, hashToCheck) {
+		return false, false, nil
+	}
+
+	if kd.updateParams {
+		if *p != *kd.Params {
+			return true, true, nil
+		}
+	}
+
+	return false, true, nil
 }
 
 func encodePasswordHash(params *Argon2idParams, salt, hash []byte) string {

--- a/main/password-hashing/argon2id_key_derivator_test.go
+++ b/main/password-hashing/argon2id_key_derivator_test.go
@@ -15,33 +15,59 @@ import (
 func TestArgon2idKeyDerivator(t *testing.T) {
 	testAuth := generateRandomAuth()
 
-	kd := NewArgon2idKeyDerivator(DefaultMemory)
-	params := kd.DefaultParams()
+	kd := NewArgon2idKeyDerivator(DefaultMemory, GetDefaultArgon2idParams(), true)
 
-	pw, err := kd.GeneratePasswordHash(context.Background(), testAuth, params)
+	pw, err := kd.GeneratePasswordHash(context.Background(), testAuth)
 	require.NoError(t, err)
 
 	decodedParams, salt, hash, err := decodePasswordHash(pw)
 	require.NoError(t, err)
-	assert.Equal(t, int(params.KeyLen), len(hash))
-	assert.Equal(t, int(params.SaltLen), len(salt))
-	assert.Equal(t, *params, *decodedParams)
+	assert.Equal(t, int(kd.Params.KeyLen), len(hash))
+	assert.Equal(t, int(kd.Params.SaltLen), len(salt))
+	assert.Equal(t, *kd.Params, *decodedParams)
 
-	ok, err := kd.CheckPassword(context.Background(), pw, testAuth)
+	needsUpdate, ok, err := kd.CheckPassword(context.Background(), pw, testAuth)
 	require.NoError(t, err)
 	assert.True(t, ok)
+	assert.False(t, needsUpdate)
+}
+
+func TestArgon2idKeyDerivator_CheckPassword_NeedsUpdate(t *testing.T) {
+	testAuth := generateRandomAuth()
+
+	kd := &Argon2idKeyDerivator{
+		Params:       GetDefaultArgon2idParams(),
+		updateParams: true,
+	}
+
+	pw, err := kd.GeneratePasswordHash(context.Background(), testAuth)
+	require.NoError(t, err)
+
+	decodedParams, salt, hash, err := decodePasswordHash(pw)
+	require.NoError(t, err)
+	assert.Equal(t, int(kd.Params.KeyLen), len(hash))
+	assert.Equal(t, int(kd.Params.SaltLen), len(salt))
+	assert.Equal(t, *kd.Params, *decodedParams)
+
+	kd.Params.Memory *= 2
+
+	needsUpdate, ok, err := kd.CheckPassword(context.Background(), pw, testAuth)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, needsUpdate)
 }
 
 func TestArgon2idKeyDerivator_NotEqual(t *testing.T) {
 	testAuth := generateRandomAuth()
 
-	kd := &Argon2idKeyDerivator{}
-	params := kd.DefaultParams()
+	kd := &Argon2idKeyDerivator{
+		Params: GetDefaultArgon2idParams(),
+	}
 
-	pw1, err := kd.GeneratePasswordHash(context.Background(), testAuth, params)
+	pw1, err := kd.GeneratePasswordHash(context.Background(), testAuth)
 	require.NoError(t, err)
 
-	pw2, err := kd.GeneratePasswordHash(context.Background(), testAuth, params)
+	pw2, err := kd.GeneratePasswordHash(context.Background(), testAuth)
 	require.NoError(t, err)
 
 	_, _, hash1, err := decodePasswordHash(pw1)
@@ -76,17 +102,17 @@ func TestDecode(t *testing.T) {
 }
 
 func TestGetArgon2idParams(t *testing.T) {
-	kd := &Argon2idKeyDerivator{}
-	defaultParams := kd.DefaultParams()
+	defaultParams := GetDefaultArgon2idParams()
 	params := GetArgon2idParams(0, 0, 0, 0, 0)
 
 	assert.Equal(t, *defaultParams, *params)
 }
 
 func BenchmarkArgon2idKeyDerivator_Default(b *testing.B) {
-	kd := &Argon2idKeyDerivator{}
-	params := kd.DefaultParams()
-	b.Log(argon2idParams(params))
+	kd := &Argon2idKeyDerivator{
+		Params: GetDefaultArgon2idParams(),
+	}
+	b.Log(argon2idParams(kd.Params))
 
 	auth := make([]byte, 32)
 	rand.Read(auth)
@@ -94,7 +120,7 @@ func BenchmarkArgon2idKeyDerivator_Default(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := kd.GeneratePasswordHash(context.Background(), authBase64, params)
+		_, err := kd.GeneratePasswordHash(context.Background(), authBase64)
 		if err != nil {
 			b.Log(err)
 		}
@@ -104,10 +130,11 @@ func BenchmarkArgon2idKeyDerivator_Default(b *testing.B) {
 const concurrency = 8
 
 func BenchmarkArgon2idKeyDerivator_Default_Concurrency(b *testing.B) {
-	kd := &Argon2idKeyDerivator{}
-	params := kd.DefaultParams()
+	kd := &Argon2idKeyDerivator{
+		Params: GetDefaultArgon2idParams(),
+	}
 	b.Log(concurrency)
-	b.Log(argon2idParams(params))
+	b.Log(argon2idParams(kd.Params))
 
 	auth := make([]byte, 32)
 	rand.Read(auth)
@@ -119,15 +146,15 @@ func BenchmarkArgon2idKeyDerivator_Default_Concurrency(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wg.Add(concurrency)
 		for n := 0; n < concurrency; n++ {
-			go gen(wg, kd, authBase64, params)
+			go gen(wg, kd, authBase64)
 		}
 		wg.Wait()
 	}
 }
 
-func gen(wg *sync.WaitGroup, kd *Argon2idKeyDerivator, authBase64 string, params *Argon2idParams) {
+func gen(wg *sync.WaitGroup, kd *Argon2idKeyDerivator, authBase64 string) {
 	defer wg.Done()
-	_, err := kd.GeneratePasswordHash(context.Background(), authBase64, params)
+	_, err := kd.GeneratePasswordHash(context.Background(), authBase64)
 	if err != nil {
 		panic(err)
 	}
@@ -138,9 +165,10 @@ func BenchmarkArgon2idKeyDerivator_TweakParams(b *testing.B) {
 	time := uint32(1)
 	threads := uint8(4)
 
-	kd := &Argon2idKeyDerivator{}
-	params := GetArgon2idParams(memMiB, time, threads, DefaultKeyLen, DefaultSaltLen)
-	b.Log(argon2idParams(params))
+	kd := &Argon2idKeyDerivator{
+		Params: GetArgon2idParams(memMiB, time, threads, DefaultKeyLen, DefaultSaltLen),
+	}
+	b.Log(argon2idParams(kd.Params))
 
 	auth := make([]byte, 32)
 	rand.Read(auth)
@@ -148,7 +176,7 @@ func BenchmarkArgon2idKeyDerivator_TweakParams(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := kd.GeneratePasswordHash(context.Background(), authBase64, params)
+		_, err := kd.GeneratePasswordHash(context.Background(), authBase64)
 		if err != nil {
 			b.Log(err)
 		}

--- a/main/storage_manager.go
+++ b/main/storage_manager.go
@@ -13,16 +13,23 @@ var (
 )
 
 type StorageManager interface {
-	StartTransaction(ctx context.Context) (transactionCtx interface{}, err error)
-	CommitTransaction(transactionCtx interface{}) error
+	StartTransaction(context.Context) (TransactionCtx, error)
 
-	StoreNewIdentity(transactionCtx interface{}, id Identity) error
-	GetIdentity(uid uuid.UUID) (Identity, error)
+	StoreIdentity(TransactionCtx, Identity) error
+	LoadIdentity(uuid.UUID) (*Identity, error)
 
-	GetUuidForPublicKey(pubKey []byte) (uuid.UUID, error)
+	GetUuidForPublicKey([]byte) (uuid.UUID, error)
+
+	StoreAuth(TransactionCtx, uuid.UUID, string) error
+	LoadAuthForUpdate(TransactionCtx, uuid.UUID) (string, error)
 
 	IsReady() error
 	Close()
+}
+
+type TransactionCtx interface {
+	Commit() error
+	Rollback() error
 }
 
 func GetStorageManager(c *Config) (StorageManager, error) {


### PR DESCRIPTION
**Added:**

- support for updating key derivation parameters of already stored password hashes "on the go":
    - if enabled, password hashes will be updated on the first incoming authorized request
    - to enable password hash update, set configuration (boolean) to `true`
        - json: `kdUpdateParams`
        - envconfig: `UBIRCH_KD_UPDATE_PARAMS` 

**Changed:**

- do not by default limit maximal total memory to use for key derivation
    - max. total memory in MiB (uint32) can be set via configuration
        - json: `kdMaxTotalMemMiB`
        - envconfig: `UBIRCH_KD_MAX_TOTAL_MEM_MIB` 