### PR TITLE
UC-343 FIX deadlock after HSM restart

### DIFF
--- a/main/go.mod
+++ b/main/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211130204445-39266ce1ec63
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20220112213241-e059ea225291
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/main/go.sum
+++ b/main/go.sum
@@ -113,8 +113,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211130204445-39266ce1ec63 h1:LuL4xAGhF73FGUCvnUlKV4bmTS3X/rFmbhdt7s3Y/mA=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211130204445-39266ce1ec63/go.mod h1:JG7PGWaipe8AGzr0QCwtS3aLvI43JCMyQAmWtJ3svwo=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20220112213241-e059ea225291 h1:laWd17wh1OYZTAB4ovQV1+YSAOXdJg8piIUeZVvZZAs=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20220112213241-e059ea225291/go.mod h1:JG7PGWaipe8AGzr0QCwtS3aLvI43JCMyQAmWtJ3svwo=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=


### PR DESCRIPTION
**Changed:**

- updated ubirch-protocol-go version to commit [e059ea2](https://github.com/ubirch/ubirch-protocol-go/commit/e059ea225291868329df681d83e040456b7535e4):

> move CKR_GENERAL_ERROR into the ‘re-establish session’ category in the error handler of the ubirch pkcs#11 crypto interface in order to prevent deadlock after restart of HSM module via csadm.
> 
> When the HSM module restarts, the session ID + key are deleted, while the TCP connection between client and module remain established. In this case, the old session ID + key become invalid, and an "invalid secure messaging ID"-error occurs when trying to create a signature. On client side, we only get a "CKR_GENERAL_ERROR" from the pkcs11 interface. In order to fix this, a new connection has to be established, i.e. tear down and re-establish the session on client side.

This commit fixes UC-343