### PR TITLE
UC-432 Response Error Codes

### DIFF
--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -44,8 +44,8 @@ const (
 	ErrCodeCertServerNotAvailable = "CS503-2000"
 	ErrCodeCertNotFound           = "CS500-2100"
 	ErrCodeCertNotValid           = "CS500-2200"
-	ErrCodeCertGeneric            = "CS500-2300"
-	ErrCodeCoseCreation           = "CS500-2400"
+	ErrCodeCertGenericError       = "CS500-2300"
+	ErrCodeCoseCreationFail       = "CS500-2400"
 )
 
 // 	COSE_Sign1 = [
@@ -128,15 +128,16 @@ func (c *CoseSigner) Sign(msg h.HTTPRequest) h.HTTPResponse {
 		case ErrCertNotValid:
 			return h.ErrorResponse(http.StatusInternalServerError, ErrCodeCertNotValid, errMsg)
 		default:
+			// this should never happen
 			log.Errorf("CoseSigner.GetSKID returned unexpected error: %v", err)
-			return h.ErrorResponse(http.StatusInternalServerError, ErrCodeCertGeneric, "")
+			return h.ErrorResponse(http.StatusInternalServerError, ErrCodeCertGenericError, "")
 		}
 	}
 
 	cose, err := c.createSignedCOSE(msg.Ctx, msg.ID, msg.Hash, skid, msg.Payload)
 	if err != nil {
 		log.Errorf("could not create COSE object for identity %s: %v", msg.ID, err)
-		return h.ErrorResponse(http.StatusInternalServerError, ErrCodeCoseCreation, "")
+		return h.ErrorResponse(http.StatusInternalServerError, ErrCodeCoseCreationFail, "")
 	}
 	log.Debugf("%s: COSE: %x", msg.ID, cose)
 

--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -240,7 +240,7 @@ func (c *CoseSigner) createSignedCOSE(ctx context.Context, uid uuid.UUID, hash h
 	}
 
 	if len(signature) != ES256_Sig_Len {
-		return nil, fmt.Errorf("invalid signature length: expected %d, got %d", ES256_Sig_Len, len(signature))
+		return nil, fmt.Errorf("invalid signature length: expected: %d bytes, got: %d bytes", ES256_Sig_Len, len(signature))
 	}
 
 	// create COSE_Sign1 object

--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -121,21 +121,21 @@ func (c *CoseSigner) Sign(msg h.HTTPRequest) h.HTTPResponse {
 	if err != nil {
 		switch err {
 		case ErrCertServerNotAvailable:
-			return h.ErrorResponse(msg.ID, http.StatusServiceUnavailable, ErrCodeCertServerNotAvailable, errMsg, true)
+			return h.ErrorResponse(msg.ID, msg.Target, http.StatusServiceUnavailable, ErrCodeCertServerNotAvailable, errMsg, true)
 		case ErrCertNotFound:
-			return h.ErrorResponse(msg.ID, http.StatusInternalServerError, ErrCodeCertNotFound, errMsg, true)
+			return h.ErrorResponse(msg.ID, msg.Target, http.StatusInternalServerError, ErrCodeCertNotFound, errMsg, true)
 		case ErrCertNotValid:
-			return h.ErrorResponse(msg.ID, http.StatusInternalServerError, ErrCodeCertNotValid, errMsg, true)
+			return h.ErrorResponse(msg.ID, msg.Target, http.StatusInternalServerError, ErrCodeCertNotValid, errMsg, true)
 		default:
 			// this should never happen
 			log.Errorf("CoseSigner.GetSKID returned unexpected error: %v", err)
-			return h.ErrorResponse(msg.ID, http.StatusInternalServerError, ErrCodeCertGenericError, errMsg, false)
+			return h.ErrorResponse(msg.ID, msg.Target, http.StatusInternalServerError, ErrCodeCertGenericError, errMsg, false)
 		}
 	}
 
 	cose, err := c.createSignedCOSE(msg.Ctx, msg.ID, msg.Hash, skid, msg.Payload)
 	if err != nil {
-		return h.ErrorResponse(msg.ID, http.StatusInternalServerError, ErrCodeCoseCreationFail, err.Error(), false)
+		return h.ErrorResponse(msg.ID, msg.Target, http.StatusInternalServerError, ErrCodeCoseCreationFail, err.Error(), false)
 	}
 	log.Debugf("%s: COSE: %x", msg.ID, cose)
 

--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -40,7 +40,7 @@ const (
 	COSE_Sign1_Context = "Signature1" // signature context identifier for COSE_Sign1 structure (https://cose-wg.github.io/cose-spec/#rfc.section.4.4)
 	ES256_Sig_Len      = 64           // length of ECDSA P-256 signatures in bytes
 
-	// error response codes
+	// response error codes
 	ErrCodeCertServerNotAvailable = "CS503-2000"
 	ErrCodeCertNotFound           = "CS500-2100"
 	ErrCodeCertNotValid           = "CS500-2200"

--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -129,22 +129,13 @@ func TestCoseSigner_Sign(t *testing.T) {
 			Content:    []byte(ErrCertNotFound.Error()),
 		},
 		{
-			name: "getSKID ErrCertExpired",
+			name: "getSKID ErrCertNotValid",
 			getSKID: func(uid uuid.UUID) ([]byte, string, error) {
-				return nil, ErrCertExpired.Error(), ErrCertExpired
+				return nil, ErrCertNotValid.Error(), ErrCertNotValid
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusInternalServerError,
-			Content:    []byte(ErrCertExpired.Error()),
-		},
-		{
-			name: "getSKID ErrCertNotYetValid",
-			getSKID: func(uid uuid.UUID) ([]byte, string, error) {
-				return nil, ErrCertNotYetValid.Error(), ErrCertNotYetValid
-			},
-			signHash:   mockSign,
-			StatusCode: http.StatusInternalServerError,
-			Content:    []byte(ErrCertNotYetValid.Error()),
+			Content:    []byte(ErrCertNotValid.Error()),
 		},
 		{
 			name: "getSKID unexpected error",

--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -149,7 +149,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusInternalServerError,
-			ErrHeader:  ErrCodeCertGeneric,
+			ErrHeader:  ErrCodeCertGenericError,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 		{
@@ -159,7 +159,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				return nil, testError
 			},
 			StatusCode: http.StatusInternalServerError,
-			ErrHeader:  ErrCodeCoseCreation,
+			ErrHeader:  ErrCodeCoseCreationFail,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 		{
@@ -169,7 +169,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				return nil, nil
 			},
 			StatusCode: http.StatusInternalServerError,
-			ErrHeader:  ErrCodeCoseCreation,
+			ErrHeader:  ErrCodeCoseCreationFail,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 	}

--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -101,6 +101,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 		getSKID    GetSKID
 		signHash   SignHash
 		StatusCode int
+		ErrHeader  string
 		Content    []byte
 	}{
 		{
@@ -108,6 +109,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			getSKID:    mockGetSKID,
 			signHash:   mockSign,
 			StatusCode: http.StatusOK,
+			ErrHeader:  "",
 			Content:    []byte{0xd2, 0x84, 0x43, 0xa1, 0x1, 0x26, 0xa1, 0x4, 0x48, 0xa3, 0x78, 0xce, 0x33, 0x3d, 0xd4, 0xf7, 0x76, 0x44, 0x74, 0x65, 0x73, 0x74, 0x58, 0x40, 0x52, 0xfd, 0xfc, 0x7, 0x21, 0x82, 0x65, 0x4f, 0x16, 0x3f, 0x5f, 0xf, 0x9a, 0x62, 0x1d, 0x72, 0x95, 0x66, 0xc7, 0x4d, 0x10, 0x3, 0x7c, 0x4d, 0x7b, 0xbb, 0x4, 0x7, 0xd1, 0xe2, 0xc6, 0x49, 0x81, 0x85, 0x5a, 0xd8, 0x68, 0x1d, 0xd, 0x86, 0xd1, 0xe9, 0x1e, 0x0, 0x16, 0x79, 0x39, 0xcb, 0x66, 0x94, 0xd2, 0xc4, 0x22, 0xac, 0xd2, 0x8, 0xa0, 0x7, 0x29, 0x39, 0x48, 0x7f, 0x69, 0x99},
 		},
 		{
@@ -117,6 +119,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusServiceUnavailable,
+			ErrHeader:  ErrCodeCertServerNotAvailable,
 			Content:    []byte(ErrCertServerNotAvailable.Error()),
 		},
 		{
@@ -126,6 +129,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusInternalServerError,
+			ErrHeader:  ErrCodeCertNotFound,
 			Content:    []byte(ErrCertNotFound.Error()),
 		},
 		{
@@ -135,6 +139,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusInternalServerError,
+			ErrHeader:  ErrCodeCertNotValid,
 			Content:    []byte(ErrCertNotValid.Error()),
 		},
 		{
@@ -144,6 +149,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			},
 			signHash:   mockSign,
 			StatusCode: http.StatusInternalServerError,
+			ErrHeader:  ErrCodeCertGeneric,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 		{
@@ -153,6 +159,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				return nil, testError
 			},
 			StatusCode: http.StatusInternalServerError,
+			ErrHeader:  ErrCodeCoseCreation,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 		{
@@ -162,6 +169,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				return nil, nil
 			},
 			StatusCode: http.StatusInternalServerError,
+			ErrHeader:  ErrCodeCoseCreation,
 			Content:    []byte(http.StatusText(http.StatusInternalServerError)),
 		},
 	}
@@ -179,6 +187,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 			resp := coseSigner.Sign(msg)
 
 			assert.Equal(t, c.StatusCode, resp.StatusCode)
+			assert.Equal(t, c.ErrHeader, resp.Header.Get(h.ErrHeader))
 			assert.Equal(t, c.Content, resp.Content)
 		})
 	}

--- a/main/http-server/cose_service.go
+++ b/main/http-server/cose_service.go
@@ -29,17 +29,7 @@ import (
 
 const (
 	HexEncoding = "hex"
-
-	HashLen = 32
-
-	// response error codes
-	ErrCodeInvalidUUID           = "CS404-0000"
-	ErrCodeMissingAuth           = "CS401-0100"
-	ErrCodeUnknownUUID           = "CS401-0200"
-	ErrCodeInvalidAuth           = "CS401-0300"
-	ErrCodeInvalidRequestContent = "CS400-0400"
-	ErrCodeInternalServerError   = "CS500-0500"
-	ErrCodeAlreadyInitialized    = "CS409-1900"
+	HashLen     = 32
 )
 
 type Sha256Sum [HashLen]byte
@@ -80,7 +70,7 @@ func (s *COSEService) HandleRequest(getUUID GetUUID, getPayloadAndHash GetPayloa
 
 		authOk, found, err := s.CheckAuth(ctx, uid, auth)
 		if err != nil {
-			Error(w, r, uid, http.StatusInternalServerError, ErrCodeInternalServerError, fmt.Sprintf("authentication check failed: %v", err))
+			Error(w, r, uid, http.StatusInternalServerError, ErrCodeAuthInternalServerError, fmt.Sprintf("authentication check failed: %v", err))
 			return
 		}
 

--- a/main/http-server/cose_service.go
+++ b/main/http-server/cose_service.go
@@ -113,7 +113,8 @@ func GetHashFromHashRequest() GetPayloadAndHash {
 
 		var data []byte
 
-		switch ContentType(r.Header) {
+		contentType := ContentType(r.Header)
+		switch contentType {
 		case TextType:
 			if ContentEncoding(r.Header) == HexEncoding {
 				data, err = hex.DecodeString(string(rBody))
@@ -130,12 +131,12 @@ func GetHashFromHashRequest() GetPayloadAndHash {
 			data = rBody
 		default:
 			return nil, Sha256Sum{}, fmt.Errorf("invalid content-type for hash: "+
-				"expected (\"%s\" | \"%s\")", BinType, TextType)
+				"expected: (%s | %s), got: %s", BinType, TextType, contentType)
 		}
 
 		if len(data) != HashLen {
 			return nil, Sha256Sum{}, fmt.Errorf("invalid SHA256 hash size: "+
-				"expected %d bytes, got %d bytes", HashLen, len(data))
+				"expected: %d bytes, got: %d bytes", HashLen, len(data))
 		}
 
 		copy(hash[:], data)
@@ -155,7 +156,8 @@ func GetPayloadAndHashFromDataRequest(getCBORFromJSON GetCBORFromJSON, getSigStr
 
 		var data []byte
 
-		switch ContentType(r.Header) {
+		contentType := ContentType(r.Header)
+		switch contentType {
 		case JSONType:
 			data, err = getCBORFromJSON(rBody)
 			if err != nil {
@@ -166,7 +168,7 @@ func GetPayloadAndHashFromDataRequest(getCBORFromJSON GetCBORFromJSON, getSigStr
 			data = rBody
 		default:
 			return nil, Sha256Sum{}, fmt.Errorf("invalid content-type for original data: "+
-				"expected (\"%s\" | \"%s\")", CBORType, JSONType)
+				"expected: (%s | %s), got: %s", CBORType, JSONType, contentType)
 		}
 
 		toBeSigned, err := getSigStructBytes(data)

--- a/main/http-server/cose_service.go
+++ b/main/http-server/cose_service.go
@@ -39,6 +39,7 @@ type HTTPRequest struct {
 	Hash    Sha256Sum
 	Payload []byte
 	Ctx     context.Context
+	Target  string
 }
 
 type CheckAuth func(context.Context, uuid.UUID, string) (bool, bool, error)
@@ -84,7 +85,7 @@ func (s *COSEService) HandleRequest(getUUID GetUUID, getPayloadAndHash GetPayloa
 			return
 		}
 
-		msg := HTTPRequest{ID: uid, Ctx: ctx}
+		msg := HTTPRequest{ID: uid, Ctx: ctx, Target: r.URL.Path}
 
 		msg.Payload, msg.Hash, err = getPayloadAndHash(r)
 		if err != nil {

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -33,6 +33,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -52,6 +53,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHashHex))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 	r.Header.Set("Content-Transfer-Encoding", HexEncoding)
 
@@ -72,6 +74,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(testHashBytes))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", BinType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -111,6 +114,7 @@ func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -130,6 +134,7 @@ func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -168,6 +173,7 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -187,6 +193,7 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHashHex))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 	r.Header.Set("Content-Transfer-Encoding", HexEncoding)
 
@@ -207,6 +214,7 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", "wrong content type")
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -226,6 +234,7 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tooShortHash))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
@@ -243,6 +252,7 @@ func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(testPayloadJSON)))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
@@ -260,6 +270,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(testPayloadJSON)))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
@@ -279,6 +290,7 @@ func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(testCBOR))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", CBORType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
@@ -296,6 +308,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(testPayloadJSON)))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
@@ -313,6 +326,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(testPayloadJSON)))
+	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
@@ -322,8 +336,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 	}
 }
 
-func mockCheckAuth(context.Context, uuid.UUID, string) (bool, bool, error) {
-	return true, true, nil
+func mockCheckAuth(c context.Context, u uuid.UUID, a string) (bool, bool, error) {
+	return a == testAuth, true, nil
 }
 
 func mockCheckAuthBad(context.Context, uuid.UUID, string) (bool, bool, error) {

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -40,6 +38,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, w.Header().Get(ErrHeader))
+	assert.Equal(t, testCose, w.Body.Bytes())
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
@@ -60,6 +59,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, w.Header().Get(ErrHeader))
+	assert.Equal(t, testCose, w.Body.Bytes())
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
@@ -79,9 +79,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, w.Header().Get(ErrHeader))
-	body, err := ioutil.ReadAll(w.Body)
-	require.NoError(t, err)
-	assert.Equal(t, testCose, body)
+	assert.Equal(t, testCose, w.Body.Bytes())
 }
 
 func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
@@ -98,8 +96,8 @@ func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURLBad, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidUUID, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, ErrCodeInvalidUUID, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
@@ -117,8 +115,8 @@ func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeUnknownUUID, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, ErrCodeUnknownUUID, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
@@ -136,8 +134,8 @@ func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInternalServerError, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, ErrCodeInternalServerError, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {
@@ -154,8 +152,8 @@ func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeMissingAuth, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, ErrCodeMissingAuth, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_InvalidAuth(t *testing.T) {
@@ -173,8 +171,8 @@ func TestCOSEService_HandleRequest_InvalidAuth(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidAuth, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, ErrCodeInvalidAuth, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
@@ -192,8 +190,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
@@ -212,8 +210,8 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
@@ -231,8 +229,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
@@ -250,8 +248,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
@@ -284,8 +282,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
@@ -320,8 +318,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
@@ -337,8 +335,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
 
-	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
 }
 
 func mockCheckAuth(c context.Context, u uuid.UUID, a string) (bool, bool, error) {

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -135,7 +135,7 @@ func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Equal(t, ErrCodeInternalServerError, w.Header().Get(ErrHeader))
+	assert.Equal(t, ErrCodeAuthInternalServerError, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -38,9 +38,8 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
@@ -59,9 +58,8 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
@@ -80,6 +78,7 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(ErrHeader))
 	body, err := ioutil.ReadAll(w.Body)
 	require.NoError(t, err)
 	assert.Equal(t, testCose, body)
@@ -99,9 +98,8 @@ func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURLBad, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusNotFound {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusNotFound)
-	}
+	assert.Equal(t, ErrCodeInvalidUUID, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
@@ -119,9 +117,8 @@ func TestCOSEService_HandleRequest_UnknownUUID(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusNotFound {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusNotFound)
-	}
+	assert.Equal(t, ErrCodeUnknownUUID, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
@@ -139,14 +136,13 @@ func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusInternalServerError)
-	}
+	assert.Equal(t, ErrCodeInternalServerError, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestCOSEService_HandleRequest_BadAuth(t *testing.T) {
+func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuthNotOk,
+		CheckAuth: mockCheckAuth,
 		Sign:      mockSign,
 	}
 
@@ -158,9 +154,27 @@ func TestCOSEService_HandleRequest_BadAuth(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusUnauthorized)
+	assert.Equal(t, ErrCodeMissingAuth, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCOSEService_HandleRequest_InvalidAuth(t *testing.T) {
+	testCOSEService := &COSEService{
+		CheckAuth: mockCheckAuth,
+		Sign:      mockSign,
 	}
+
+	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(testHash))
+	r.Header.Set(AuthHeader, "password")
+	r.Header.Set("Content-Type", TextType)
+
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
+
+	assert.Equal(t, ErrCodeInvalidAuth, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
@@ -178,9 +192,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
@@ -199,9 +212,8 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
@@ -219,9 +231,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
@@ -239,9 +250,8 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetHashFromHashRequest())(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
@@ -257,9 +267,8 @@ func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
@@ -275,9 +284,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
@@ -295,9 +303,8 @@ func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(ErrHeader))
 }
 
 func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
@@ -313,9 +320,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
@@ -331,9 +337,8 @@ func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 
 	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("unexpected response status: %d, expected: %d", w.Code, http.StatusBadRequest)
-	}
+	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func mockCheckAuth(c context.Context, u uuid.UUID, a string) (bool, bool, error) {
@@ -346,10 +351,6 @@ func mockCheckAuthBad(context.Context, uuid.UUID, string) (bool, bool, error) {
 
 func mockCheckAuthNotFound(context.Context, uuid.UUID, string) (bool, bool, error) {
 	return false, false, nil
-}
-
-func mockCheckAuthNotOk(context.Context, uuid.UUID, string) (bool, bool, error) {
-	return false, true, nil
 }
 
 func mockSign(HTTPRequest) HTTPResponse {

--- a/main/http-server/csr_fetcher.go
+++ b/main/http-server/csr_fetcher.go
@@ -35,7 +35,7 @@ func FetchCSR(registerAuth string, getUUID GetUUID, getCSR GetCSR) http.HandlerF
 			case ErrUnknown:
 				Error(w, r, uid, http.StatusNotFound, ErrCodeUnknownUUID, err.Error())
 			default:
-				Error(w, r, uid, http.StatusInternalServerError, ErrCodeInternalServerError, fmt.Sprintf("generating CSR failed: %v", err))
+				Error(w, r, uid, http.StatusInternalServerError, ErrCodeGenericInternalServerError, fmt.Sprintf("generating CSR failed: %v", err))
 			}
 			return
 		}

--- a/main/http-server/csr_fetcher.go
+++ b/main/http-server/csr_fetcher.go
@@ -18,14 +18,14 @@ func FetchCSR(registerAuth string, getUUID GetUUID, getCSR GetCSR) http.HandlerF
 			return
 		}
 
-		uid, err := getUUID(r)
-		if err != nil {
-			Error(w, r, uid, http.StatusNotFound, ErrCodeInvalidUUID, err.Error())
+		if auth != registerAuth {
+			Error(w, r, uuid.Nil, http.StatusUnauthorized, ErrCodeInvalidAuth, "invalid auth token")
 			return
 		}
 
-		if auth != registerAuth {
-			Error(w, r, uid, http.StatusUnauthorized, ErrCodeInvalidAuth, "invalid auth token")
+		uid, err := getUUID(r)
+		if err != nil {
+			Error(w, r, uid, http.StatusNotFound, ErrCodeInvalidUUID, err.Error())
 			return
 		}
 

--- a/main/http-server/csr_fetcher.go
+++ b/main/http-server/csr_fetcher.go
@@ -1,27 +1,31 @@
 package http_server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type GetCSR func(uid uuid.UUID) (csr []byte, err error)
 
-func FetchCSR(auth string, getUUID GetUUID, getCSR GetCSR) http.HandlerFunc {
+func FetchCSR(registerAuth string, getUUID GetUUID, getCSR GetCSR) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(AuthHeader) != auth {
-			log.Warnf("unauthorized CSR request")
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		auth := r.Header.Get(AuthHeader)
+
+		if auth == "" {
+			Error(w, r, uuid.Nil, http.StatusUnauthorized, ErrCodeMissingAuth, fmt.Sprintf("missing authentication header %s", AuthHeader))
 			return
 		}
 
 		uid, err := getUUID(r)
 		if err != nil {
-			log.Warnf("FetchCSR: %v", err)
-			http.Error(w, err.Error(), http.StatusNotFound)
+			Error(w, r, uid, http.StatusNotFound, ErrCodeInvalidUUID, err.Error())
+			return
+		}
+
+		if auth != registerAuth {
+			Error(w, r, uid, http.StatusUnauthorized, ErrCodeInvalidAuth, "invalid auth token")
 			return
 		}
 
@@ -29,10 +33,9 @@ func FetchCSR(auth string, getUUID GetUUID, getCSR GetCSR) http.HandlerFunc {
 		if err != nil {
 			switch err {
 			case ErrUnknown:
-				Error(uid, w, err, http.StatusNotFound)
+				Error(w, r, uid, http.StatusNotFound, ErrCodeUnknownUUID, err.Error())
 			default:
-				log.Errorf("%s: %v", uid, err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				Error(w, r, uid, http.StatusInternalServerError, ErrCodeInternalServerError, fmt.Sprintf("generating CSR failed: %v", err))
 			}
 			return
 		}

--- a/main/http-server/csr_fetcher_test.go
+++ b/main/http-server/csr_fetcher_test.go
@@ -107,7 +107,7 @@ func TestFetchCSR(t *testing.T) {
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				assert.Equal(t, http.StatusInternalServerError, recorder.Code)
-				assert.Equal(t, ErrCodeInternalServerError, recorder.Header().Get(ErrHeader))
+				assert.Equal(t, ErrCodeGenericInternalServerError, recorder.Header().Get(ErrHeader))
 				assert.Contains(t, recorder.Body.String(), http.StatusText(http.StatusInternalServerError))
 			},
 		},

--- a/main/http-server/csr_fetcher_test.go
+++ b/main/http-server/csr_fetcher_test.go
@@ -37,7 +37,7 @@ func TestFetchCSR(t *testing.T) {
 			},
 		},
 		{
-			name:      "unauthorized",
+			name:      "missing auth",
 			callerUrl: path.Join("/", uuid.NewString(), CSREndpoint),
 			auth:      "",
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
@@ -45,7 +45,20 @@ func TestFetchCSR(t *testing.T) {
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), http.StatusText(http.StatusUnauthorized))
+				require.Contains(t, recorder.Body.String(), "missing authentication header X-Auth-Token")
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name:      "invalid auth",
+			callerUrl: path.Join("/", uuid.NewString(), CSREndpoint),
+			auth:      "password",
+			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
+				return uid.NodeID(), nil
+			},
+			getUuid: GetUUIDFromRequest,
+			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Contains(t, recorder.Body.String(), "invalid auth token")
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
 			},
 		},

--- a/main/http-server/csr_fetcher_test.go
+++ b/main/http-server/csr_fetcher_test.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testCSR = []byte{0x7, 0x21, 0x82, 0x81, 0x85, 0x5a, 0xd8, 0x68, 0x1d, 0xd, 0x86, 0xd1, 0xe9, 0x1e, 0x0, 0x16, 0x79, 0x39, 0xcb, 0x66, 0x94}
 )
 
 func TestFetchCSR(t *testing.T) {
@@ -28,12 +32,13 @@ func TestFetchCSR(t *testing.T) {
 			callerUrl: path.Join("/", testUuid.String(), CSREndpoint),
 			auth:      testAuth,
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
-				return uid.NodeID(), nil
+				return testCSR, nil
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Equal(t, testUuid.NodeID(), recorder.Body.Bytes())
-				require.Equal(t, http.StatusOK, recorder.Code)
+				assert.Equal(t, http.StatusOK, recorder.Code)
+				assert.Empty(t, recorder.Header().Get(ErrHeader))
+				assert.Equal(t, testCSR, recorder.Body.Bytes())
 			},
 		},
 		{
@@ -41,12 +46,13 @@ func TestFetchCSR(t *testing.T) {
 			callerUrl: path.Join("/", uuid.NewString(), CSREndpoint),
 			auth:      "",
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
-				return uid.NodeID(), nil
+				return testCSR, nil
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "missing authentication header X-Auth-Token")
-				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+				assert.Equal(t, ErrCodeMissingAuth, recorder.Header().Get(ErrHeader))
+				assert.Contains(t, recorder.Body.String(), "missing authentication header X-Auth-Token")
 			},
 		},
 		{
@@ -54,12 +60,13 @@ func TestFetchCSR(t *testing.T) {
 			callerUrl: path.Join("/", uuid.NewString(), CSREndpoint),
 			auth:      "password",
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
-				return uid.NodeID(), nil
+				return testCSR, nil
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "invalid auth token")
-				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+				assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+				assert.Equal(t, ErrCodeInvalidAuth, recorder.Header().Get(ErrHeader))
+				assert.Contains(t, recorder.Body.String(), "invalid auth token")
 			},
 		},
 		{
@@ -67,12 +74,13 @@ func TestFetchCSR(t *testing.T) {
 			callerUrl: path.Join("/", "2222", CSREndpoint),
 			auth:      testAuth,
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
-				return uid.NodeID(), nil
+				return testCSR, nil
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "invalid UUID")
-				require.Equal(t, http.StatusNotFound, recorder.Code)
+				assert.Equal(t, http.StatusNotFound, recorder.Code)
+				assert.Equal(t, ErrCodeInvalidUUID, recorder.Header().Get(ErrHeader))
+				assert.Contains(t, recorder.Body.String(), "invalid UUID")
 			},
 		},
 		{
@@ -84,12 +92,13 @@ func TestFetchCSR(t *testing.T) {
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "unknown identity")
-				require.Equal(t, http.StatusNotFound, recorder.Code)
+				assert.Equal(t, http.StatusNotFound, recorder.Code)
+				assert.Equal(t, ErrCodeUnknownUUID, recorder.Header().Get(ErrHeader))
+				assert.Contains(t, recorder.Body.String(), "unknown identity")
 			},
 		},
 		{
-			name:      "unknown uuid internal server error",
+			name:      "internal server error",
 			callerUrl: path.Join("/", testUuid.String(), CSREndpoint),
 			auth:      testAuth,
 			getCsR: func(uid uuid.UUID) (csr []byte, err error) {
@@ -97,8 +106,9 @@ func TestFetchCSR(t *testing.T) {
 			},
 			getUuid: GetUUIDFromRequest,
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.NotEmpty(t, recorder.Body.String())
-				require.Equal(t, http.StatusInternalServerError, recorder.Code)
+				assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+				assert.Equal(t, ErrCodeInternalServerError, recorder.Header().Get(ErrHeader))
+				assert.Contains(t, recorder.Body.String(), http.StatusText(http.StatusInternalServerError))
 			},
 		},
 	}

--- a/main/http-server/helper.go
+++ b/main/http-server/helper.go
@@ -25,7 +25,7 @@ func GetUUIDFromRequest(r *http.Request) (uuid.UUID, error) {
 	uuidParam := chi.URLParam(r, UUIDKey)
 	uid, err := uuid.Parse(uuidParam)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("invalid UUID: \"%s\": %v", uuidParam, err)
+		return uuid.Nil, fmt.Errorf("invalid UUID: %s: %v", uuidParam, err)
 	}
 	return uid, nil
 }

--- a/main/http-server/http_server.go
+++ b/main/http-server/http_server.go
@@ -41,6 +41,16 @@ const (
 
 	AuthHeader = "X-Auth-Token"
 	ErrHeader  = "X-Err"
+
+	// response error codes
+	ErrCodeInvalidUUID                = "CS404-0000"
+	ErrCodeMissingAuth                = "CS401-0100"
+	ErrCodeUnknownUUID                = "CS401-0200"
+	ErrCodeInvalidAuth                = "CS401-0300"
+	ErrCodeInvalidRequestContent      = "CS400-0400"
+	ErrCodeAuthInternalServerError    = "CS500-0500"
+	ErrCodeGenericInternalServerError = "CS500-1500"
+	ErrCodeAlreadyInitialized         = "CS409-1900"
 )
 
 var UUIDPath = fmt.Sprintf("/{%s}", UUIDKey)

--- a/main/http-server/http_server.go
+++ b/main/http-server/http_server.go
@@ -40,6 +40,7 @@ const (
 	CBORType = "application/cbor"
 
 	AuthHeader = "X-Auth-Token"
+	ErrHeader  = "X-Err"
 )
 
 var UUIDPath = fmt.Sprintf("/{%s}", UUIDKey)

--- a/main/http-server/identity_registerer.go
+++ b/main/http-server/identity_registerer.go
@@ -53,7 +53,7 @@ func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFu
 			case ErrUnknown:
 				Error(w, r, uid, http.StatusNotFound, ErrCodeUnknownUUID, err.Error())
 			default:
-				Error(w, r, uid, http.StatusInternalServerError, ErrCodeInternalServerError, fmt.Sprintf("identity initialization failed: %v", err))
+				Error(w, r, uid, http.StatusInternalServerError, ErrCodeGenericInternalServerError, fmt.Sprintf("identity initialization failed: %v", err))
 			}
 			return
 		}

--- a/main/http-server/identity_registerer.go
+++ b/main/http-server/identity_registerer.go
@@ -76,7 +76,7 @@ func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFu
 func identityFromBody(r *http.Request) (RegistrationPayload, error) {
 	contentType := ContentType(r.Header)
 	if contentType != JSONType {
-		return RegistrationPayload{}, fmt.Errorf("invalid content-type: expected %s, got %s", JSONType, contentType)
+		return RegistrationPayload{}, fmt.Errorf("invalid content-type: expected: %s, got: %s", JSONType, contentType)
 	}
 
 	var payload RegistrationPayload

--- a/main/http-server/identity_registerer.go
+++ b/main/http-server/identity_registerer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 
-	log "github.com/sirupsen/logrus"
 	prom "github.com/ubirch/ubirch-cose-client-go/main/prometheus"
 )
 
@@ -26,16 +25,21 @@ type InitializeIdentity func(uid uuid.UUID) (csr []byte, pw string, err error)
 
 func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(AuthHeader) != registerAuth {
-			log.Warnf("unauthorized registration attempt")
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		auth := r.Header.Get(AuthHeader)
+
+		if auth == "" {
+			Error(w, r, uuid.Nil, http.StatusUnauthorized, ErrCodeMissingAuth, fmt.Sprintf("missing authentication header %s", AuthHeader))
+			return
+		}
+
+		if auth != registerAuth {
+			Error(w, r, uuid.Nil, http.StatusUnauthorized, ErrCodeInvalidAuth, "invalid auth token")
 			return
 		}
 
 		idPayload, err := identityFromBody(r)
 		if err != nil {
-			log.Warn(err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			Error(w, r, idPayload.Uid, http.StatusBadRequest, ErrCodeInvalidRequestContent, err.Error())
 			return
 		}
 
@@ -45,12 +49,11 @@ func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFu
 		if err != nil {
 			switch err {
 			case ErrAlreadyInitialized:
-				Error(uid, w, err, http.StatusConflict)
+				Error(w, r, uid, http.StatusConflict, ErrCodeAlreadyInitialized, err.Error())
 			case ErrUnknown:
-				Error(uid, w, err, http.StatusNotFound)
+				Error(w, r, uid, http.StatusNotFound, ErrCodeUnknownUUID, err.Error())
 			default:
-				log.Errorf("%s: identity registration failed: %v", uid, err)
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				Error(w, r, uid, http.StatusInternalServerError, ErrCodeInternalServerError, fmt.Sprintf("identity initialization failed: %v", err))
 			}
 			return
 		}
@@ -82,10 +85,10 @@ func identityFromBody(r *http.Request) (RegistrationPayload, error) {
 		return RegistrationPayload{}, err
 	}
 	if payload.Uid == uuid.Nil {
-		return RegistrationPayload{}, fmt.Errorf("empty uuid")
+		return RegistrationPayload{}, fmt.Errorf("missing UUID for identity registration")
 	}
 	if len(payload.Pwd) != 0 {
-		return RegistrationPayload{}, fmt.Errorf("setting password is not longer supported. password will be generated and registered automatically")
+		return RegistrationPayload{}, fmt.Errorf("attempt to set password for identity in registration request content: setting password is not longer supported, password will be generated and registered internally")
 	}
 	return payload, nil
 }

--- a/main/http-server/identity_registerer_test.go
+++ b/main/http-server/identity_registerer_test.go
@@ -65,7 +65,7 @@ func TestRegister(t *testing.T) {
 				return byteStr, "", nil
 			},
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "empty uuid")
+				require.Contains(t, recorder.Body.String(), "missing UUID for identity registration")
 				require.Equal(t, http.StatusBadRequest, recorder.Code)
 			},
 		},
@@ -81,12 +81,12 @@ func TestRegister(t *testing.T) {
 				return byteStr, "", nil
 			},
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), "setting password is not longer supported.")
+				require.Contains(t, recorder.Body.String(), "setting password is not longer supported")
 				require.Equal(t, http.StatusBadRequest, recorder.Code)
 			},
 		},
 		{
-			name:        "not authorized",
+			name:        "missing auth",
 			auth:        "",
 			contentType: JSONType,
 			body: RegistrationPayload{
@@ -96,7 +96,22 @@ func TestRegister(t *testing.T) {
 				return byteStr, "", nil
 			},
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
-				require.Contains(t, recorder.Body.String(), http.StatusText(http.StatusUnauthorized))
+				require.Contains(t, recorder.Body.String(), "missing authentication header X-Auth-Token")
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name:        "invalid auth",
+			auth:        "password",
+			contentType: JSONType,
+			body: RegistrationPayload{
+				Uid: uuid.New(),
+			},
+			initId: func(uid uuid.UUID) (csr []byte, pw string, err error) {
+				return byteStr, "", nil
+			},
+			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Contains(t, recorder.Body.String(), "invalid auth token")
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
 			},
 		},

--- a/main/http-server/identity_registerer_test.go
+++ b/main/http-server/identity_registerer_test.go
@@ -38,7 +38,7 @@ func TestRegister(t *testing.T) {
 			tcChecks: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				assert.Equal(t, http.StatusOK, recorder.Code)
 				assert.Empty(t, recorder.Header().Get(ErrHeader))
-				assert.Contains(t, testCSR, recorder.Body.Bytes())
+				assert.Equal(t, testCSR, recorder.Body.Bytes())
 			},
 		},
 		{

--- a/main/http-server/resp.go
+++ b/main/http-server/resp.go
@@ -99,8 +99,8 @@ type errorLog struct {
 	StatusCode int    `json:"statusCode"`
 }
 
-// Error is a wrapper for http.Error that additionally logs uuid, request URL path, error message and status
-// with logging level "warning" for client errors and "error" for server errors.
+// Error is a wrapper for http.Error that additionally logs error context with logging
+// level "warning" for client errors and logging level "error" for server errors.
 // The error message for server errors will only be logged but not be sent to the client.
 func Error(w http.ResponseWriter, r *http.Request, uid uuid.UUID, httpCode int, errCode, errMsg string) {
 	e := errorLog{

--- a/main/http-server/resp.go
+++ b/main/http-server/resp.go
@@ -18,8 +18,10 @@ type HTTPResponse struct {
 
 // SendResponse forwards a response to the client
 func SendResponse(w http.ResponseWriter, resp HTTPResponse) {
-	for k, v := range resp.Header {
-		w.Header().Set(k, v[0])
+	for key, values := range resp.Header {
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, err := w.Write(resp.Content)
@@ -28,9 +30,9 @@ func SendResponse(w http.ResponseWriter, resp HTTPResponse) {
 	}
 }
 
-func ErrorResponse(httpCode int, errCode, message string) HTTPResponse {
-	if message == "" {
-		message = http.StatusText(httpCode)
+func ErrorResponse(httpCode int, errCode, errMsg string) HTTPResponse {
+	if errMsg == "" {
+		errMsg = http.StatusText(httpCode)
 	}
 
 	header := http.Header{"Content-Type": {"text/plain; charset=utf-8"}}
@@ -41,7 +43,7 @@ func ErrorResponse(httpCode int, errCode, message string) HTTPResponse {
 	return HTTPResponse{
 		StatusCode: httpCode,
 		Header:     header,
-		Content:    []byte(message),
+		Content:    []byte(errMsg),
 	}
 }
 

--- a/main/http-server/resp.go
+++ b/main/http-server/resp.go
@@ -30,12 +30,13 @@ func SendResponse(w http.ResponseWriter, resp HTTPResponse) {
 	}
 }
 
-func ErrorResponse(uid uuid.UUID, httpCode int, errCode, errMsg string, exposeErrMsg bool) HTTPResponse {
+func ErrorResponse(uid uuid.UUID, target string, httpCode int, errCode, errMsg string, exposeErrMsg bool) HTTPResponse {
 	errLog, _ := json.Marshal(errorLog{
 		Uid:        uid.String(),
 		Error:      errMsg,
 		ErrCode:    errCode,
 		StatusCode: httpCode,
+		Target:     target,
 	})
 	log.Errorf("ServerError: %s", errLog)
 
@@ -93,10 +94,10 @@ func Ready(server string, readinessChecks []func() error) http.HandlerFunc {
 
 type errorLog struct {
 	Uid        string `json:"sealID,omitempty"`
-	Target     string `json:"target,omitempty"`
 	Error      string `json:"error"`
 	ErrCode    string `json:"errorCode,omitempty"`
 	StatusCode int    `json:"statusCode"`
+	Target     string `json:"target,omitempty"`
 }
 
 // Error is a wrapper for http.Error that additionally logs error context with logging
@@ -104,10 +105,10 @@ type errorLog struct {
 // The error message for server errors will only be logged but not be sent to the client.
 func Error(w http.ResponseWriter, r *http.Request, uid uuid.UUID, httpCode int, errCode, errMsg string) {
 	e := errorLog{
-		Target:     r.URL.Path,
 		Error:      errMsg,
 		ErrCode:    errCode,
 		StatusCode: httpCode,
+		Target:     r.URL.Path,
 	}
 	if uid != uuid.Nil {
 		e.Uid = uid.String()

--- a/main/http-server/resp.go
+++ b/main/http-server/resp.go
@@ -27,13 +27,19 @@ func SendResponse(w http.ResponseWriter, resp HTTPResponse) {
 	}
 }
 
-func ErrorResponse(code int, message string) HTTPResponse {
+func ErrorResponse(httpCode int, errorCode, message string) HTTPResponse {
 	if message == "" {
-		message = http.StatusText(code)
+		message = http.StatusText(httpCode)
 	}
+
+	header := http.Header{"Content-Type": {"text/plain; charset=utf-8"}}
+	if errorCode != "" {
+		header.Add(ErrHeader, errorCode)
+	}
+
 	return HTTPResponse{
-		StatusCode: code,
-		Header:     http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
+		StatusCode: httpCode,
+		Header:     header,
 		Content:    []byte(message),
 	}
 }

--- a/main/http-server/resp_test.go
+++ b/main/http-server/resp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,6 +29,42 @@ func TestSendResponse(t *testing.T) {
 	assert.Equal(t, TextType, w.Header().Get("Content-Type"))
 	assert.Equal(t, testAuth, w.Header().Get(AuthHeader))
 	assert.Equal(t, resp.Content, w.Body.Bytes())
+}
+
+func TestErrorResponse(t *testing.T) {
+	testCases := []struct {
+		name        string
+		httpCode    int
+		errCode     string
+		message     string
+		respContent string
+	}{
+		{
+			name:        "bad request",
+			httpCode:    http.StatusBadRequest,
+			errCode:     ErrCodeInvalidRequestContent,
+			message:     "bad request",
+			respContent: "bad request",
+		},
+		{
+			name:        "internal server error",
+			httpCode:    http.StatusInternalServerError,
+			errCode:     "",
+			message:     "",
+			respContent: http.StatusText(http.StatusInternalServerError),
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+
+			resp := ErrorResponse(c.httpCode, c.errCode, c.message)
+
+			assert.Equal(t, c.httpCode, resp.StatusCode)
+			assert.Equal(t, c.errCode, resp.Header.Get(ErrHeader))
+			assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+			assert.Equal(t, c.respContent, string(resp.Content))
+		})
+	}
 }
 
 func TestHealth(t *testing.T) {
@@ -80,6 +117,54 @@ func TestReady(t *testing.T) {
 			assert.Equal(t, server, w.Header().Get("Server"))
 			assert.Equal(t, TextType, w.Header().Get("Content-Type"))
 			assert.Equal(t, []byte(http.StatusText(c.code)+"\n"), w.Body.Bytes())
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	testCases := []struct {
+		name        string
+		uid         uuid.UUID
+		httpCode    int
+		errCode     string
+		errMsg      string
+		respContent string
+	}{
+		{
+			name:        "client error",
+			httpCode:    http.StatusBadRequest,
+			errCode:     ErrCodeInvalidRequestContent,
+			errMsg:      "bad request",
+			respContent: "bad request",
+		},
+		{
+			name:        "server error",
+			httpCode:    http.StatusInternalServerError,
+			errCode:     "",
+			errMsg:      "server error",
+			respContent: http.StatusText(http.StatusInternalServerError),
+		},
+		{
+			name:        "invalid status code",
+			httpCode:    0,
+			errCode:     "",
+			errMsg:      "some error",
+			respContent: "",
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			testTarget := "/test/target"
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, testTarget, nil)
+
+			Error(w, r, c.uid, c.httpCode, c.errCode, c.errMsg)
+
+			assert.Equal(t, c.httpCode, w.Code)
+			assert.Equal(t, c.errCode, w.Header().Get(ErrHeader))
+			assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+			assert.Contains(t, w.Body.String(), c.respContent)
 		})
 	}
 }

--- a/main/http-server/resp_test.go
+++ b/main/http-server/resp_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testTarget = "/test/target"
+
 func TestSendResponse(t *testing.T) {
 	header := http.Header{}
 	header.Set("Content-Type", TextType)
@@ -60,7 +62,7 @@ func TestErrorResponse(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 
-			resp := ErrorResponse(testUUID, c.httpCode, c.errCode, c.message, c.exposeErrMsg)
+			resp := ErrorResponse(testUUID, testTarget, c.httpCode, c.errCode, c.message, c.exposeErrMsg)
 
 			assert.Equal(t, c.httpCode, resp.StatusCode)
 			assert.Equal(t, c.errCode, resp.Header.Get(ErrHeader))
@@ -157,8 +159,6 @@ func TestError(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			testTarget := "/test/target"
-
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, testTarget, nil)
 

--- a/main/identity_handler.go
+++ b/main/identity_handler.go
@@ -112,7 +112,7 @@ func (i *IdentityHandler) InitIdentity(uid uuid.UUID) (csrPEM []byte, auth strin
 func (i *IdentityHandler) CreateCSR(uid uuid.UUID) (csrPEM []byte, err error) {
 	keyExists, err := i.Crypto.PrivateKeyExists(uid)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for existence of private key: %v", err)
+		return nil, fmt.Errorf("could not check for existence of private key: %v", err)
 	}
 
 	if !keyExists {
@@ -121,7 +121,7 @@ func (i *IdentityHandler) CreateCSR(uid uuid.UUID) (csrPEM []byte, err error) {
 
 	csr, err := i.Crypto.GetCSR(uid, i.subjectCountry, i.subjectOrganization)
 	if err != nil {
-		return nil, fmt.Errorf("could not generate CSR: %v", err)
+		return nil, fmt.Errorf("could not create CSR: %v", err)
 	}
 
 	csrPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})

--- a/main/skid_handler.go
+++ b/main/skid_handler.go
@@ -145,7 +145,7 @@ func (s *SkidHandler) matchCertificate(cert Certificate) (uuid.UUID, *skidCtx) {
 	skidString := base64.StdEncoding.EncodeToString(cert.Kid)
 
 	if len(cert.Kid) != SkidLen {
-		log.Errorf("%s: invalid KID length: %d, expected: %d", skidString, len(cert.Kid), SkidLen)
+		log.Errorf("%s: invalid KID length: expected: %d bytes, got: %d bytes", skidString, SkidLen, len(cert.Kid))
 		return uuid.Nil, nil
 	}
 

--- a/main/skid_handler.go
+++ b/main/skid_handler.go
@@ -57,8 +57,6 @@ func NewSkidHandler(certs GetCertificateList, uid GetUuid, enc EncodePublicKey, 
 		skidStore:      nil,
 		skidStoreMutex: &sync.RWMutex{},
 
-		certLoadFailCounter: 0,
-
 		getCerts:  certs,
 		getUuid:   uid,
 		encPubKey: enc,
@@ -91,33 +89,7 @@ func (s *SkidHandler) loadSKIDs() {
 	certs, err := s.getCerts()
 	if err != nil {
 		log.Errorf("unable to retrieve public key certificate list (trustList): %v", err)
-
-		s.certLoadFailCounter++
-		s.isCertServerAvailable.Store(false)
-
-		if !s.lastSuccessfulCertLoad.IsZero() {
-			errMsg := fmt.Sprintf("trustList could not be loaded since %s", s.lastSuccessfulCertLoad.Format(timeLayout))
-
-			if s.certLoadFailCounter < s.maxCertLoadFailCount {
-				// we have not yet reached the maximum amount of failed attempts to load the certificate list,
-				// return and try again later
-				log.Warnf(errMsg+", local SKID lookup will be cleared in %s if this issue persists",
-					time.Duration(s.maxCertLoadFailCount-s.certLoadFailCounter)*s.certLoadInterval)
-			} else if s.certLoadFailCounter == s.maxCertLoadFailCount {
-				// we have reached the maximum amount of failed attempts to load the certificate list,
-				// clear the SKID lookup
-				log.Errorf(errMsg+", clearing local SKID lookup after %d failed attempts to load public key certificate list",
-					s.certLoadFailCounter)
-
-				s.resetSkidStore()
-			} else {
-				// we surpassed the maximum amount of failed attempts to load the certificate list,
-				// SKID lookup has been cleared
-				log.Warnf(errMsg+", local SKID lookup was cleared %s ago",
-					time.Duration(s.certLoadFailCounter-s.maxCertLoadFailCount)*s.certLoadInterval)
-			}
-		}
-
+		s.handleCertLoadFail()
 		return
 	}
 
@@ -130,73 +102,112 @@ func (s *SkidHandler) loadSKIDs() {
 
 	// go through certificate list and match known public keys
 	for _, cert := range certs {
-		skidString := base64.StdEncoding.EncodeToString(cert.Kid)
-
-		if len(cert.Kid) != SkidLen {
-			log.Errorf("%s: invalid KID length: %d, expected: %d", skidString, len(cert.Kid), SkidLen)
+		uid, matchedSkid := s.matchCertificate(cert)
+		if matchedSkid == nil {
 			continue
 		}
 
-		// get public key from certificate
-		certificate, err := x509.ParseCertificate(cert.RawData)
-		if err != nil {
-			log.Errorf("%s: parsing x509 certificate failed: %v", skidString, err)
-			continue
-		}
-
-		pubKeyPEM, err := s.encPubKey(certificate.PublicKey)
-		if err != nil {
-			log.Debugf("%s: unable to encode public key from x509 certificate: %v", skidString, err)
-			continue
-		}
-
-		// look up matching UUID for public key
-		uid, err := s.getUuid(pubKeyPEM)
-		if err != nil {
-			if err == ErrNotExist {
-				log.Debugf("%s: public key from x509 certificate does not match any known identity", skidString)
-			} else {
-				log.Errorf("%s: public key lookup failed: %v", skidString, err)
-			}
-			continue
-		}
-		log.Debugf("%s: public key match: %s", skidString, uid)
-
-		matchedSkid := skidCtx{
-			SKID:      cert.Kid,
-			NotBefore: certificate.NotBefore,
-			NotAfter:  certificate.NotAfter,
-		}
-
-		// check validity of certificate
-		now := time.Now()
-
-		if now.After(matchedSkid.NotAfter) {
-			log.Debugf("%s: certificate expired: valid until %s", skidString, matchedSkid.NotAfter.Format(timeLayout))
-			matchedSkid.expired = true
-		} else if now.Before(matchedSkid.NotBefore) {
-			log.Debugf("%s: certificate not yet valid: valid from %s", skidString, matchedSkid.NotBefore.Format(timeLayout))
-		} else {
-			matchedSkid.Valid = true
-		}
-
-		if previouslyMatchedSkid, ok := tempSkidStore[uid]; ok {
-			if previouslyMatchedSkid.Valid && !matchedSkid.Valid {
-				continue
-			}
-
-			// if there is more than one valid certificate, use the newer one, i.e. the one that starts being valid at a later time
-			if (previouslyMatchedSkid.Valid && matchedSkid.Valid) || (!previouslyMatchedSkid.Valid && !matchedSkid.Valid) {
-				if matchedSkid.NotBefore.Before(previouslyMatchedSkid.NotBefore) {
-					continue
-				}
-			}
-		}
-
-		tempSkidStore[uid] = matchedSkid
+		s.checkCertificateValidity(uid, matchedSkid, &tempSkidStore)
 	}
 
 	s.updateSkidStore(tempSkidStore)
+}
+
+func (s *SkidHandler) handleCertLoadFail() {
+	s.certLoadFailCounter++
+	s.isCertServerAvailable.Store(false)
+
+	if !s.lastSuccessfulCertLoad.IsZero() {
+		errMsg := fmt.Sprintf("trustList could not be loaded since %s", s.lastSuccessfulCertLoad.Format(timeLayout))
+
+		if s.certLoadFailCounter < s.maxCertLoadFailCount {
+			// we have not yet reached the maximum amount of failed attempts to load the certificate list,
+			// return and try again later
+			log.Warnf(errMsg+", local SKID lookup will be cleared in %s if this issue persists",
+				time.Duration(s.maxCertLoadFailCount-s.certLoadFailCounter)*s.certLoadInterval)
+		} else if s.certLoadFailCounter == s.maxCertLoadFailCount {
+			// we have reached the maximum amount of failed attempts to load the certificate list,
+			// clear the SKID lookup
+			log.Errorf(errMsg+", clearing local SKID lookup after %d failed attempts to load public key certificate list",
+				s.certLoadFailCounter)
+
+			s.resetSkidStore()
+		} else {
+			// we surpassed the maximum amount of failed attempts to load the certificate list,
+			// SKID lookup has been cleared
+			log.Warnf(errMsg+", local SKID lookup was cleared %s ago",
+				time.Duration(s.certLoadFailCounter-s.maxCertLoadFailCount)*s.certLoadInterval)
+		}
+	}
+}
+
+func (s *SkidHandler) matchCertificate(cert Certificate) (uuid.UUID, *skidCtx) {
+	skidString := base64.StdEncoding.EncodeToString(cert.Kid)
+
+	if len(cert.Kid) != SkidLen {
+		log.Errorf("%s: invalid KID length: %d, expected: %d", skidString, len(cert.Kid), SkidLen)
+		return uuid.Nil, nil
+	}
+
+	// get public key from certificate
+	certificate, err := x509.ParseCertificate(cert.RawData)
+	if err != nil {
+		log.Errorf("%s: parsing x509 certificate failed: %v", skidString, err)
+		return uuid.Nil, nil
+	}
+
+	pubKeyPEM, err := s.encPubKey(certificate.PublicKey)
+	if err != nil {
+		log.Debugf("%s: unable to encode public key from x509 certificate: %v", skidString, err)
+		return uuid.Nil, nil
+	}
+
+	// look up matching UUID for public key
+	uid, err := s.getUuid(pubKeyPEM)
+	if err != nil {
+		if err == ErrNotExist {
+			log.Debugf("%s: public key from x509 certificate does not match any known identity", skidString)
+		} else {
+			log.Errorf("%s: public key lookup failed: %v", skidString, err)
+		}
+		return uuid.Nil, nil
+	}
+	log.Debugf("%s: public key match: %s", skidString, uid)
+
+	return uid, &skidCtx{
+		SKID:      cert.Kid,
+		NotBefore: certificate.NotBefore,
+		NotAfter:  certificate.NotAfter,
+	}
+}
+
+func (s *SkidHandler) checkCertificateValidity(uid uuid.UUID, skid *skidCtx, skidStore *map[uuid.UUID]skidCtx) {
+	skidString := base64.StdEncoding.EncodeToString(skid.SKID)
+	now := time.Now()
+
+	if now.After(skid.NotAfter) {
+		log.Debugf("%s: certificate expired: valid until %s", skidString, skid.NotAfter.Format(timeLayout))
+		skid.expired = true
+	} else if now.Before(skid.NotBefore) {
+		log.Debugf("%s: certificate not yet valid: valid from %s", skidString, skid.NotBefore.Format(timeLayout))
+	} else {
+		skid.Valid = true
+	}
+
+	if previouslyMatchedSkid, ok := (*skidStore)[uid]; ok {
+		if previouslyMatchedSkid.Valid && !skid.Valid {
+			return
+		}
+
+		// if the certificates are both valid or invalid, use the newer one, i.e. the one that starts being valid at a later time
+		if (previouslyMatchedSkid.Valid && skid.Valid) || (!previouslyMatchedSkid.Valid && !skid.Valid) {
+			if skid.NotBefore.Before(previouslyMatchedSkid.NotBefore) {
+				return
+			}
+		}
+	}
+
+	(*skidStore)[uid] = *skid
 }
 
 func (s *SkidHandler) setSkidStore(newSkidStore map[uuid.UUID]skidCtx) {

--- a/main/skid_handler_test.go
+++ b/main/skid_handler_test.go
@@ -71,8 +71,8 @@ func TestSkidHandler(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		certs             GetCertificateList
-		uid               GetUuid
+		certs             LoadCertificateList
+		uid               LookupUuid
 		enc               EncodePublicKey
 		reloadEveryMinute bool
 		tcChecks          func(t *testing.T, s *SkidHandler)
@@ -119,7 +119,7 @@ func TestSkidHandler(t *testing.T) {
 
 				//// the following lines test the scheduler to trigger the loadSKIDs method after one minute
 				//// since the execution of this test takes over a minute it is commented out
-				//s.getCerts = mockGetCertificateList([]validity{})
+				//s.loadCertList = mockGetCertificateList([]validity{})
 				//
 				//t.Logf("waiting %s for scheduler to reload certificate list...", s.certLoadInterval.String())
 				//time.Sleep(s.certLoadInterval + time.Second)
@@ -138,7 +138,7 @@ func TestSkidHandler(t *testing.T) {
 				assert.Empty(t, errMsg)
 				require.Equal(t, testSKID, skid)
 
-				s.getCerts = mockGetCertificateList([]validity{
+				s.loadCertList = mockGetCertificateList([]validity{
 					{
 						PrivPEM:   priv,
 						NotBefore: time.Now(),
@@ -178,7 +178,7 @@ func TestSkidHandler(t *testing.T) {
 			enc:               crypto.EncodePublicKey,
 			reloadEveryMinute: true,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
-				s.getCerts = mockGetCertificateListBad
+				s.loadCertList = mockGetCertificateListBad
 
 				for i := 0; i < s.maxCertLoadFailCount; i++ {
 					assert.NotEmpty(t, len(s.skidStore))
@@ -408,7 +408,7 @@ type validity struct {
 	SKID      []byte
 }
 
-func mockGetCertificateList(v []validity) GetCertificateList {
+func mockGetCertificateList(v []validity) LoadCertificateList {
 	return func() ([]Certificate, error) {
 		var certList []Certificate
 

--- a/main/skid_handler_test.go
+++ b/main/skid_handler_test.go
@@ -41,6 +41,34 @@ func TestSkidHandler(t *testing.T) {
 		getPubKeyID(pub): uid,
 	}
 
+	validSinceNow := validity{
+		PrivPEM:   priv,
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+		SKID:      testSKID,
+	}
+
+	validSinceAnHourAgo := validity{
+		PrivPEM:   priv,
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		SKID:      testSKID2,
+	}
+
+	expired := validity{
+		PrivPEM:   priv,
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(-time.Minute),
+		SKID:      testSKID2,
+	}
+
+	notYetValid := validity{
+		PrivPEM:   priv,
+		NotBefore: time.Now().Add(time.Minute),
+		NotAfter:  time.Now().Add(time.Hour),
+		SKID:      testSKID2,
+	}
+
 	testCases := []struct {
 		name              string
 		certs             GetCertificateList
@@ -50,15 +78,8 @@ func TestSkidHandler(t *testing.T) {
 		tcChecks          func(t *testing.T, s *SkidHandler)
 	}{
 		{
-			name: "NewSkidHandler",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
+			name:              "NewSkidHandler",
+			certs:             mockGetCertificateList([]validity{validSinceNow}),
 			uid:               testUUIDs.mockGetUuidForPublicKey,
 			enc:               crypto.EncodePublicKey,
 			reloadEveryMinute: false,
@@ -78,19 +99,12 @@ func TestSkidHandler(t *testing.T) {
 
 				_, errMsg, err = s.GetSKID(uuid.New())
 				assert.Equal(t, ErrCertNotFound, err)
-				assert.Contains(t, errMsg, ErrCertNotFound.Error())
+				assert.Equal(t, fmt.Sprintf("SKID unknown: %v", ErrCertNotFound), errMsg)
 			},
 		},
 		{
-			name: "NewSkidHandler reloadEveryMinute",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
+			name:              "NewSkidHandler reloadEveryMinute",
+			certs:             mockGetCertificateList([]validity{validSinceNow}),
 			uid:               testUUIDs.mockGetUuidForPublicKey,
 			enc:               crypto.EncodePublicKey,
 			reloadEveryMinute: true,
@@ -114,17 +128,10 @@ func TestSkidHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "loadSKIDs",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
-			uid: testUUIDs.mockGetUuidForPublicKey,
-			enc: crypto.EncodePublicKey,
+			name:  "loadSKIDs",
+			certs: mockGetCertificateList([]validity{validSinceNow}),
+			uid:   testUUIDs.mockGetUuidForPublicKey,
+			enc:   crypto.EncodePublicKey,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
 				skid, errMsg, err := s.GetSKID(uid)
 				require.NoError(t, err)
@@ -161,20 +168,12 @@ func TestSkidHandler(t *testing.T) {
 
 				_, errMsg, err := s.GetSKID(uid)
 				assert.Equal(t, ErrCertServerNotAvailable, err)
-				assert.Contains(t, errMsg, ErrCertServerNotAvailable.Error())
-				assert.Contains(t, errMsg, "trustList could not be loaded for 1h0m0s")
+				assert.Equal(t, fmt.Sprintf("%v: trustList could not be loaded for 1h0m0s", ErrCertServerNotAvailable), errMsg)
 			},
 		},
 		{
-			name: "BadGetCertificateList_MaxCertLoadFailCount",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
+			name:              "BadGetCertificateList_MaxCertLoadFailCount",
+			certs:             mockGetCertificateList([]validity{validSinceNow}),
 			uid:               testUUIDs.mockGetUuidForPublicKey,
 			enc:               crypto.EncodePublicKey,
 			reloadEveryMinute: true,
@@ -219,16 +218,9 @@ func TestSkidHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "bad encPubKey",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
-			uid: testUUIDs.mockGetUuidForPublicKey,
+			name:  "bad encPubKey",
+			certs: mockGetCertificateList([]validity{validSinceNow}),
+			uid:   testUUIDs.mockGetUuidForPublicKey,
 			enc: func(interface{}) ([]byte, error) {
 				return nil, testError
 			},
@@ -239,90 +231,67 @@ func TestSkidHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "GetUuidFindsNothing",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
-			uid: mockGetUuidFindsNothing,
-			enc: crypto.EncodePublicKey,
+			name:  "GetUuidFindsNothing",
+			certs: mockGetCertificateList([]validity{validSinceNow}),
+			uid:   mockGetUuidFindsNothing,
+			enc:   crypto.EncodePublicKey,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
 				assert.Empty(t, s.skidStore)
 			},
 		},
 		{
-			name: "GetUuidReturnsError",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
-			uid: mockGetUuidReturnsError,
-			enc: crypto.EncodePublicKey,
+			name:  "GetUuidReturnsError",
+			certs: mockGetCertificateList([]validity{validSinceNow}),
+			uid:   mockGetUuidReturnsError,
+			enc:   crypto.EncodePublicKey,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
 				assert.Empty(t, s.skidStore)
 			},
 		},
 		{
-			name: "certificate validity expired",
+			name:  "certificate validity expired",
+			certs: mockGetCertificateList([]validity{expired}),
+			uid:   testUUIDs.mockGetUuidForPublicKey,
+			enc:   crypto.EncodePublicKey,
+			tcChecks: func(t *testing.T, s *SkidHandler) {
+				skid, errMsg, err := s.GetSKID(uid)
+				assert.Equal(t, ErrCertNotValid, err)
+				assert.Equal(t, fmt.Sprintf("%v: certificate expired: was valid until %s", ErrCertNotValid, expired.NotAfter.UTC().Format(timeLayout)), errMsg)
+				assert.Empty(t, skid)
+			},
+		},
+		{
+			name:  "certificate not yet valid",
+			certs: mockGetCertificateList([]validity{notYetValid}),
+			uid:   testUUIDs.mockGetUuidForPublicKey,
+			enc:   crypto.EncodePublicKey,
+			tcChecks: func(t *testing.T, s *SkidHandler) {
+				skid, errMsg, err := s.GetSKID(uid)
+				assert.Equal(t, ErrCertNotValid, err)
+				assert.Equal(t, fmt.Sprintf("%v: certificate not yet valid: will be valid from %s", ErrCertNotValid, notYetValid.NotBefore.UTC().Format(timeLayout)), errMsg)
+				assert.Empty(t, skid)
+			},
+		},
+		{
+			name: "do not overwrite previouslyMatchedSkid with notYetValid",
 			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(-time.Hour),
-					NotAfter:  time.Now().Add(-time.Minute),
-					SKID:      testSKID,
-				},
+				validSinceNow,
+				notYetValid,
 			}),
 			uid: testUUIDs.mockGetUuidForPublicKey,
 			enc: crypto.EncodePublicKey,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
-				_, errMsg, err := s.GetSKID(uid)
-				assert.Equal(t, ErrCertExpired, err)
-				assert.Contains(t, errMsg, ErrCertExpired.Error())
-				assert.Contains(t, errMsg, s.skidStore[uid].NotAfter.String())
+				skid, errMsg, err := s.GetSKID(uid)
+				require.NoError(t, err)
+				assert.Empty(t, errMsg)
+				assert.Equal(t, testSKID, skid)
 			},
 		},
 		{
-			name: "certificate not yet valid",
+			name: "do not overwrite previouslyMatchedSkid with expired",
 			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(time.Minute),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-			}),
-			uid: testUUIDs.mockGetUuidForPublicKey,
-			enc: crypto.EncodePublicKey,
-			tcChecks: func(t *testing.T, s *SkidHandler) {
-				_, errMsg, err := s.GetSKID(uid)
-				assert.Equal(t, ErrCertNotYetValid, err)
-				assert.Contains(t, errMsg, ErrCertNotYetValid.Error())
-				assert.Contains(t, errMsg, s.skidStore[uid].NotBefore.String())
-			},
-		},
-		{
-			name: "do not overwrite previouslyMatchedSkid",
-			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(time.Minute),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID2,
-				},
+				validSinceNow,
+				expired,
 			}),
 			uid: testUUIDs.mockGetUuidForPublicKey,
 			enc: crypto.EncodePublicKey,
@@ -336,18 +305,8 @@ func TestSkidHandler(t *testing.T) {
 		{
 			name: "use newer of two valid certificates",
 			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now(),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(-time.Hour),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID2,
-				},
+				validSinceNow,
+				validSinceAnHourAgo,
 			}),
 			uid: testUUIDs.mockGetUuidForPublicKey,
 			enc: crypto.EncodePublicKey,
@@ -361,24 +320,16 @@ func TestSkidHandler(t *testing.T) {
 		{
 			name: "use newer of two invalid certificates",
 			certs: mockGetCertificateList([]validity{
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(time.Minute),
-					NotAfter:  time.Now().Add(time.Hour),
-					SKID:      testSKID,
-				},
-				{
-					PrivPEM:   priv,
-					NotBefore: time.Now().Add(-time.Hour),
-					NotAfter:  time.Now().Add(-time.Minute),
-					SKID:      testSKID2,
-				},
+				notYetValid,
+				expired,
 			}),
 			uid: testUUIDs.mockGetUuidForPublicKey,
 			enc: crypto.EncodePublicKey,
 			tcChecks: func(t *testing.T, s *SkidHandler) {
-				_, _, err := s.GetSKID(uid)
-				assert.Equal(t, ErrCertNotYetValid, err)
+				skid, errMsg, err := s.GetSKID(uid)
+				assert.Equal(t, ErrCertNotValid, err)
+				assert.Equal(t, fmt.Sprintf("%v: certificate not yet valid: will be valid from %s", ErrCertNotValid, notYetValid.NotBefore.UTC().Format(timeLayout)), errMsg)
+				assert.Empty(t, skid)
 			},
 		},
 	}

--- a/main/skid_handler_test.go
+++ b/main/skid_handler_test.go
@@ -189,6 +189,10 @@ func TestSkidHandler(t *testing.T) {
 
 				assert.Equal(t, s.maxCertLoadFailCount, s.certLoadFailCounter)
 				assert.Empty(t, s.skidStore)
+
+				s.loadSKIDs()
+				assert.Equal(t, s.maxCertLoadFailCount+1, s.certLoadFailCounter)
+				assert.Empty(t, s.skidStore)
 			},
 		},
 		{


### PR DESCRIPTION
**Added:**

- added error codes to HTTP response headers. The name of the new header is: **`X-Err`**
- extended error log map (JSON) with additional error context information, i.e. sealID, error code, request target
  - all server errors are logged with logging level "**error**"
  - all client errors are logged with logging level "**warning**" 
- return specific error in case of missing authorization header (as opposed to a more generic "unauthorized" error)
- increased test coverage of `http_server` package (coverage: 88.5% of statements)

**Changed:**

- refactored SKID handler (e.g. extracted methods, enhanced variable and function names) for enhanced readability and maintainability, extended error logs, aligned timestamp format in logs, enhanced unit tests