### PR TITLE
CPI-332 remove sensitive data from logs

### DIFF
--- a/main/config/config.go
+++ b/main/config/config.go
@@ -30,7 +30,10 @@ import (
 )
 
 const (
-	ProdStage = "prod"
+	DEV_STAGE  = "dev"
+	DEMO_STAGE = "demo"
+	QA_STAGE   = "qa"
+	PROD_STAGE = "prod"
 
 	tlsCertsFileName = "%s_ubirch_tls_certs.json"
 
@@ -93,6 +96,7 @@ type Config struct {
 	KdUpdateParams            bool   `json:"kdUpdateParams" envconfig:"KD_UPDATE_PARAMS"`                   // update key derivation parameters of already existing password hashes
 	RequestLimit              int    `json:"requestLimit" envconfig:"REQUEST_LIMIT"`                        // limits number of currently processed (incoming) requests at a time
 	RequestBacklogLimit       int    `json:"requestBacklogLimit" envconfig:"REQUEST_BACKLOG_LIMIT"`         // backlog for holding a finite number of pending requests
+	IsDevelopment             bool   // (set automatically depending on env) flag signifying if the environment is development (true) or productive (false)
 	ServerTLSCertFingerprints map[string][32]byte
 	DbParams                  *DatabaseParams
 }
@@ -195,7 +199,12 @@ func (c *Config) checkMandatory() error {
 	}
 
 	if len(c.Env) == 0 {
-		c.Env = ProdStage
+		c.Env = PROD_STAGE
+	}
+
+	// set flag for non-production environments
+	if c.Env == DEV_STAGE || c.Env == DEMO_STAGE || c.Env == QA_STAGE {
+		c.IsDevelopment = true
 	}
 
 	return nil

--- a/main/config/config_test.go
+++ b/main/config/config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"ignoreUnknownCerts":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"requestLimit":0,"requestBacklogLimit":0,"ServerTLSCertFingerprints":null,"DbParams":null}`
+	expectedConfig = `{"registerAuth":"","env":"","pkcs11Module":"","pkcs11ModulePin":"","pkcs11ModuleSlotNr":0,"postgresDSN":"","dbMaxOpenConns":"","dbMaxIdleConns":"","dbConnMaxLifetime":"","dbConnMaxIdleTime":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"certificateServer":"","certificateServerPubKey":"","reloadCertsEveryMinute":false,"ignoreUnknownCerts":false,"certifyApiUrl":"","certifyApiAuth":"","kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"requestLimit":0,"requestBacklogLimit":0,"IsDevelopment":false,"ServerTLSCertFingerprints":null,"DbParams":null}`
 )
 
 func TestConfig(t *testing.T) {
@@ -108,5 +108,5 @@ func TestConfig_checkMandatory(t *testing.T) {
 
 	err = conf.checkMandatory()
 	require.NoError(t, err)
-	assert.Equal(t, ProdStage, conf.Env)
+	assert.Equal(t, PROD_STAGE, conf.Env)
 }

--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -139,7 +139,7 @@ func (c *CoseSigner) Sign(msg h.HTTPRequest) h.HTTPResponse {
 	}
 	log.Debugf("%s: COSE: %x", msg.ID, cose)
 
-	infos := fmt.Sprintf("\"hwDeviceId\":\"%s\", \"hash\":\"%s\"", msg.ID, base64.StdEncoding.EncodeToString(msg.Hash[:]))
+	infos := fmt.Sprintf("\"hwDeviceId\":\"%s\"", msg.ID)
 	auditlogger.AuditLog("create", "COSE", infos)
 
 	return h.HTTPResponse{

--- a/main/cose_signer.go
+++ b/main/cose_signer.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -113,9 +112,7 @@ func NewCoseSigner(sign SignHash, skid GetSKID) (*CoseSigner, error) {
 	}, nil
 }
 
-func (c *CoseSigner) Sign(msg h.HTTPRequest, logDebugSensitiveData h.LogDebugSensitiveData) h.HTTPResponse {
-	logDebugSensitiveData("%s: hash: %s", msg.ID, base64.StdEncoding.EncodeToString(msg.Hash[:]))
-
+func (c *CoseSigner) Sign(msg h.HTTPRequest) h.HTTPResponse {
 	skid, errMsg, err := c.GetSKID(msg.ID)
 	if err != nil {
 		switch err {
@@ -136,7 +133,6 @@ func (c *CoseSigner) Sign(msg h.HTTPRequest, logDebugSensitiveData h.LogDebugSen
 	if err != nil {
 		return h.ErrorResponse(msg.ID, msg.Target, http.StatusInternalServerError, ErrCodeCoseCreationFail, err.Error(), false)
 	}
-	logDebugSensitiveData("%s: COSE: %x", msg.ID, cose)
 
 	infos := fmt.Sprintf("\"hwDeviceId\":\"%s\"", msg.ID)
 	auditlogger.AuditLog("create", "COSE", infos)

--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -69,7 +69,7 @@ func TestCoseSigner(t *testing.T) {
 		Ctx:     context.Background(),
 	}
 
-	resp := coseSigner.Sign(msg)
+	resp := coseSigner.Sign(msg, func(string, ...interface{}) {})
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	t.Logf("signed COSE [CBOR]: %x", resp.Content)
@@ -184,7 +184,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				Payload: []byte("test"),
 			}
 
-			resp := coseSigner.Sign(msg)
+			resp := coseSigner.Sign(msg, func(string, ...interface{}) {})
 
 			assert.Equal(t, c.StatusCode, resp.StatusCode)
 			assert.Equal(t, c.ErrHeader, resp.Header.Get(h.ErrHeader))

--- a/main/cose_signer_test.go
+++ b/main/cose_signer_test.go
@@ -69,7 +69,7 @@ func TestCoseSigner(t *testing.T) {
 		Ctx:     context.Background(),
 	}
 
-	resp := coseSigner.Sign(msg, func(string, ...interface{}) {})
+	resp := coseSigner.Sign(msg)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	t.Logf("signed COSE [CBOR]: %x", resp.Content)
@@ -184,7 +184,7 @@ func TestCoseSigner_Sign(t *testing.T) {
 				Payload: []byte("test"),
 			}
 
-			resp := coseSigner.Sign(msg, func(string, ...interface{}) {})
+			resp := coseSigner.Sign(msg)
 
 			assert.Equal(t, c.StatusCode, resp.StatusCode)
 			assert.Equal(t, c.ErrHeader, resp.Header.Get(h.ErrHeader))

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -366,7 +366,7 @@ func mockCheckAuthNotFound(context.Context, uuid.UUID, string) (bool, bool, erro
 	return false, false, nil
 }
 
-func mockSign(HTTPRequest, LogDebugSensitiveData) HTTPResponse {
+func mockSign(HTTPRequest) HTTPResponse {
 	return HTTPResponse{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": {BinType}},

--- a/main/http-server/cose_service_test.go
+++ b/main/http-server/cose_service_test.go
@@ -23,8 +23,9 @@ var (
 
 func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -43,8 +44,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Base64(t *testing.T) {
 
 func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHashHex := "76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881f"
@@ -64,8 +66,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Hex(t *testing.T) {
 
 func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHashBytes, _ := hex.DecodeString("76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881f")
@@ -84,8 +87,9 @@ func TestCOSEServiceHandleRequest_HashRequest_Bytes(t *testing.T) {
 
 func TestCOSEService_HandleRequest_BadUUID(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -140,8 +144,9 @@ func TestCOSEService_HandleRequest_BadAuthCheck(t *testing.T) {
 
 func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -158,8 +163,9 @@ func TestCOSEService_HandleRequest_MissingAuth(t *testing.T) {
 
 func TestCOSEService_HandleRequest_InvalidAuth(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -177,8 +183,9 @@ func TestCOSEService_HandleRequest_InvalidAuth(t *testing.T) {
 
 func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g"
@@ -196,8 +203,9 @@ func TestCOSEService_HandleRequest_HashRequest_BadHash_Base64(t *testing.T) {
 
 func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHashHex := "76e114443cd386716c0f8408ce99e0017d07e68fef22ade5b39966941b35881ff"
@@ -216,8 +224,9 @@ func TestCOSEServiceHandleRequest_HashRequest_BadHash_Hex(t *testing.T) {
 
 func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testHash := "9HKjChmwbHoHpMuX1OXgUgf6bPLNrQT/mCXw0JUk37g="
@@ -235,8 +244,9 @@ func TestCOSEService_HandleRequest_HashRequest_BadContentType(t *testing.T) {
 
 func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	tooShortHash := "x/Ef/8VDEjvybn2gvxGeiA=="
@@ -254,8 +264,9 @@ func TestCOSEService_HandleRequest_HashRequest_BadHashLen(t *testing.T) {
 
 func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	w := httptest.NewRecorder()
@@ -263,7 +274,7 @@ func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
-	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, testCOSEService.GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, w.Header().Get(ErrHeader))
@@ -271,8 +282,9 @@ func TestCOSEService_HandleRequest_DataRequest_JSON(t *testing.T) {
 
 func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	w := httptest.NewRecorder()
@@ -280,7 +292,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
-	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, testCOSEService.GetPayloadAndHashFromDataRequest(mockGetCBORFromJSONBad, mockGetSigStructBytes))(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
@@ -288,8 +300,9 @@ func TestCOSEService_HandleRequest_DataRequest_BadJSON(t *testing.T) {
 
 func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	testCBOR, _ := hex.DecodeString("a164746573746568656c6c6f")
@@ -299,7 +312,7 @@ func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", CBORType)
 
-	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, testCOSEService.GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, w.Header().Get(ErrHeader))
@@ -307,8 +320,9 @@ func TestCOSEService_HandleRequest_DataRequest_CBOR(t *testing.T) {
 
 func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	w := httptest.NewRecorder()
@@ -316,7 +330,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", TextType)
 
-	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, testCOSEService.GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytes))(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
@@ -324,8 +338,9 @@ func TestCOSEService_HandleRequest_DataRequest_BadContentType(t *testing.T) {
 
 func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 	testCOSEService := &COSEService{
-		CheckAuth: mockCheckAuth,
-		Sign:      mockSign,
+		CheckAuth:             mockCheckAuth,
+		Sign:                  mockSign,
+		LogDebugSensitiveData: func(string, ...interface{}) {},
 	}
 
 	w := httptest.NewRecorder()
@@ -333,7 +348,7 @@ func TestCOSEService_HandleRequest_DataRequest_BadSigStructBytes(t *testing.T) {
 	r.Header.Set(AuthHeader, testAuth)
 	r.Header.Set("Content-Type", JSONType)
 
-	testCOSEService.HandleRequest(mockGetUUIDFromURL, GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
+	testCOSEService.HandleRequest(mockGetUUIDFromURL, testCOSEService.GetPayloadAndHashFromDataRequest(mockGetCBORFromJSON, mockGetSigStructBytesBad))(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, ErrCodeInvalidRequestContent, w.Header().Get(ErrHeader))
@@ -351,7 +366,7 @@ func mockCheckAuthNotFound(context.Context, uuid.UUID, string) (bool, bool, erro
 	return false, false, nil
 }
 
-func mockSign(HTTPRequest) HTTPResponse {
+func mockSign(HTTPRequest, LogDebugSensitiveData) HTTPResponse {
 	return HTTPResponse{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": {BinType}},

--- a/main/http-server/http_server.go
+++ b/main/http-server/http_server.go
@@ -98,6 +98,11 @@ func InitHTTPServer(conf *config.Config,
 	signingService := &COSEService{
 		CheckAuth: checkAuth,
 		Sign:      sign,
+		LogDebugSensitiveData: func(format string, args ...interface{}) {
+			if conf.IsDevelopment {
+				log.Debugf(format, args...)
+			}
+		},
 	}
 
 	httpServer.Router.Route(UUIDPath, func(r chi.Router) {
@@ -105,7 +110,7 @@ func InitHTTPServer(conf *config.Config,
 		// set up endpoint for CSRs: /<uuid>/csr
 		r.Get(CSREndpoint, FetchCSR(conf.RegisterAuth, GetUUIDFromRequest, getCSR))
 		// set up endpoint for COSE CBOR signing: /<uuid>/cbor
-		r.Post(CBORPath, signingService.HandleRequest(GetUUIDFromRequest, GetPayloadAndHashFromDataRequest(getCBORFromJSON, getSigStructBytes)))
+		r.Post(CBORPath, signingService.HandleRequest(GetUUIDFromRequest, signingService.GetPayloadAndHashFromDataRequest(getCBORFromJSON, getSigStructBytes)))
 		// set up endpoint for COSE CBOR hash signing: /<uuid>/cbor/hash
 		r.Post(path.Join(CBORPath, HashEndpoint), signingService.HandleRequest(GetUUIDFromRequest, GetHashFromHashRequest()))
 	})


### PR DESCRIPTION
**Removed:**

- removed DCC hash from audit log
- disabled debug-logging of sensitive data on production environment